### PR TITLE
fix thread-local bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ macro_rules! thread_local {
 #[doc(hidden)]
 macro_rules! __thread_local_inner {
     ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty, $init:expr) => {
-        $(#[$attr])* $vis const $name: $crate::thread::LocalKey<$t> =
+        $(#[$attr])* $vis static $name: $crate::thread::LocalKey<$t> =
             $crate::thread::LocalKey {
                 init: (|| { $init }) as fn() -> $t,
                 _p: std::marker::PhantomData,


### PR DESCRIPTION
The loom implementation fo thread-locals appears to work most of the
time. However, in some cases, when running models in release model,
thread-local values appear to vanish.

This patch fixes the bug. The cause of the bug is using `const` instead
of `static` for defining the thread-local key type. By using `const`,
there is no guarantee of a single instance of the key. It is surprising
that, to date, the thread-local implementation appeared to mostly work.