### PR TITLE
Change `last_dependent_accesses` for atomics

### DIFF
--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -149,8 +149,8 @@ impl State {
         action: Action,
     ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
         match action {
-            Action::Load => Box::new(self.last_store.iter()),
-            Action::Store => Box::new(self.last_load.iter()),
+            Action::Load => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
+            Action::Store => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
             Action::Rmw => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
         }
     }


### PR DESCRIPTION
Consider the following program (`x` is a shared variable, the `SeqCst`
ordering is assumed):
* thread 0 (main): store 0 in x
* thread 1: store 1 in x
* thread 2: store 2 in x
* thread 0 (main): wait for thread 1; wait for thread 2; load x

Without this change, concurrent writes are considered independent, so
Loom fails to explore `store 2` followed by `store 1`.

For orderings other than `SeqCst`, this is likely to introduce
redundant dependencies, resulting in more thread interleavings being
explored than necessary.