### PR TITLE
Some performance improvements

### DIFF
--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -19,6 +19,14 @@ impl Access {
         self.dpor_vv.set(version);
     }
 
+    pub(crate) fn set_or_create(access: &mut Option<Self>, path_id: usize, version: &VersionVec) {
+        if let Some(access) = access.as_mut() {
+            access.set(path_id, version);
+        } else {
+            *access = Some(Access::new(path_id, version));
+        }
+    }
+
     /// Location in the path
     pub(crate) fn path_id(&self) -> usize {
         self.path_id

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -14,6 +14,11 @@ impl Access {
         }
     }
 
+    pub(crate) fn set(&mut self, path_id: usize, version: &VersionVec) {
+        self.path_id = path_id;
+        self.dpor_vv.set(version);
+    }
+
     /// Location in the path
     pub(crate) fn path_id(&self) -> usize {
         self.path_id

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -134,17 +134,9 @@ impl State {
     }
 
     pub(super) fn set_last_access(&mut self, action: Action, path_id: usize, version: &VersionVec) {
-        let set_or_create = |access: &mut Option<Access>| {
-            if let Some(access) = access.as_mut() {
-                access.set(path_id, version);
-            } else {
-                *access = Some(Access::new(path_id, version));
-            }
-        };
-
         match action {
-            Action::RefInc => set_or_create(&mut self.last_ref_inc),
-            Action::RefDec => set_or_create(&mut self.last_ref_dec),
+            Action::RefInc => Access::set_or_create(&mut self.last_ref_inc, path_id, version),
+            Action::RefDec => Access::set_or_create(&mut self.last_ref_dec, path_id, version),
         }
     }
 }

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -121,14 +121,15 @@ impl State {
         assert_eq!(0, self.ref_cnt, "Arc leaked");
     }
 
-    pub(super) fn last_dependent_accesses<'a>(
-        &'a self,
+    pub(super) fn for_each_last_dependent_access(
+        &self,
         action: Action,
-    ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
+        mut f: impl FnMut(&Access)
+    ) {
         match action {
             // RefIncs are not dependent w/ RefDec, only inspections
-            Action::RefInc => Box::new([].into_iter()),
-            Action::RefDec => Box::new(self.last_ref_dec.iter()),
+            Action::RefInc => {}
+            Action::RefDec => self.last_ref_dec.iter().for_each(f),
         }
     }
 

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -154,20 +154,12 @@ impl State {
     }
 
     pub(super) fn set_last_access(&mut self, action: Action, path_id: usize, version: &VersionVec) {
-        let set_or_create = |access: &mut Option<Access>| {
-            if let Some(access) = access.as_mut() {
-                access.set(path_id, version);
-            } else {
-                *access = Some(Access::new(path_id, version));
-            }
-        };
-
         match action {
-            Action::Load => set_or_create(&mut self.last_load),
-            Action::Store => set_or_create(&mut self.last_store),
+            Action::Load => Access::set_or_create(&mut self.last_load, path_id, version),
+            Action::Store => Access::set_or_create(&mut self.last_store, path_id, version),
             Action::Rmw => {
-                set_or_create(&mut self.last_load);
-                set_or_create(&mut self.last_store);
+                Access::set_or_create(&mut self.last_load, path_id, version);
+                Access::set_or_create(&mut self.last_store, path_id, version);
             }
         }
     }

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -153,13 +153,21 @@ impl State {
         self.last_store.iter().for_each(&mut f);
     }
 
-    pub(super) fn set_last_access(&mut self, action: Action, access: Access) {
+    pub(super) fn set_last_access(&mut self, action: Action, path_id: usize, version: &VersionVec) {
+        let set_or_create = |access: &mut Option<Access>| {
+            if let Some(access) = access.as_mut() {
+                access.set(path_id, version);
+            } else {
+                *access = Some(Access::new(path_id, version));
+            }
+        };
+
         match action {
-            Action::Load => self.last_load = Some(access),
-            Action::Store => self.last_store = Some(access),
+            Action::Load => set_or_create(&mut self.last_load),
+            Action::Store => set_or_create(&mut self.last_store),
             Action::Rmw => {
-                self.last_load = Some(access.clone());
-                self.last_store = Some(access);
+                set_or_create(&mut self.last_load);
+                set_or_create(&mut self.last_store);
             }
         }
     }

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -144,15 +144,13 @@ pub(crate) fn fence(order: Ordering) {
 }
 
 impl State {
-    pub(super) fn last_dependent_accesses<'a>(
-        &'a self,
-        action: Action,
-    ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
-        match action {
-            Action::Load => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
-            Action::Store => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
-            Action::Rmw => Box::new({ self.last_load.iter().chain(self.last_store.iter()) }),
-        }
+    pub(super) fn for_each_last_dependent_access(
+        &self,
+        _action: Action,
+        mut f: impl FnMut(&Access),
+    ) {
+        self.last_load.iter().for_each(&mut f);
+        self.last_store.iter().for_each(&mut f);
     }
 
     pub(super) fn set_last_access(&mut self, action: Action, access: Access) {

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, thread, Access, Mutex};
+use crate::rt::{self, thread, Access, Mutex, VersionVec};
 
 use std::collections::VecDeque;
 
@@ -90,7 +90,11 @@ impl State {
         self.last_access.iter().for_each(f);
     }
 
-    pub(super) fn set_last_access(&mut self, access: Access) {
-        self.last_access = Some(access);
+    pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
+        if let Some(access) = self.last_access.as_mut() {
+            access.set(path_id, version);
+        } else {
+            self.last_access = Some(Access::new(path_id, version));
+        }
     }
 }

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -91,10 +91,6 @@ impl State {
     }
 
     pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
-        if let Some(access) = self.last_access.as_mut() {
-            access.set(path_id, version);
-        } else {
-            self.last_access = Some(Access::new(path_id, version));
-        }
+        Access::set_or_create(&mut self.last_access, path_id, version);
     }
 }

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -86,8 +86,8 @@ impl Condvar {
 }
 
 impl State {
-    pub(super) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(super) fn for_each_last_dependent_access(&self, f: impl FnMut(&Access)) {
+        self.last_access.iter().for_each(f);
     }
 
     pub(super) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -121,15 +121,17 @@ impl Execution {
                 None => continue,
             };
 
-            for access in self.objects.last_dependent_accesses(operation) {
-                if access.happens_before(&th.dpor_vv) {
-                    // The previous access happened before this access, thus
-                    // there is no race.
-                    continue;
-                }
+            let path = &mut self.path;
+            self.objects
+                .for_each_last_dependent_access(operation, |access| {
+                    if access.happens_before(&th.dpor_vv) {
+                        // The previous access happened before this access, thus
+                        // there is no race.
+                        return;
+                    }
 
-                self.path.backtrack(access.path_id(), th_id);
-            }
+                    path.backtrack(access.path_id(), th_id);
+                });
         }
 
         // It's important to avoid pre-emption as much as possible
@@ -201,9 +203,10 @@ impl Execution {
             let threads = &mut self.threads;
             let th_id = threads.active_id();
 
-            for access in self.objects.last_dependent_accesses(operation) {
-                threads.active_mut().dpor_vv.join(access.version());
-            }
+            self.objects
+                .for_each_last_dependent_access(operation, |access| {
+                    threads.active_mut().dpor_vv.join(access.version());
+                });
 
             threads.active_mut().dpor_vv[th_id] += 1;
 

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -1,5 +1,5 @@
 use crate::rt::alloc::Allocation;
-use crate::rt::{object, thread, Access, Path};
+use crate::rt::{object, thread, Path};
 
 use std::collections::HashMap;
 use std::fmt;
@@ -211,7 +211,7 @@ impl Execution {
             threads.active_mut().dpor_vv[th_id] += 1;
 
             self.objects
-                .set_last_access(operation, Access::new(path_id, &threads.active().dpor_vv));
+                .set_last_access(operation, path_id, &threads.active().dpor_vv);
         }
 
         // Reactivate yielded threads, but only if the current active thread is

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{thread, Access, Synchronize};
+use crate::rt::{thread, Access, Synchronize, VersionVec};
 
 use std::sync::atomic::Ordering::{Acquire, Release};
 
@@ -137,7 +137,11 @@ impl State {
         self.last_access.iter().for_each(f);
     }
 
-    pub(crate) fn set_last_access(&mut self, access: Access) {
-        self.last_access = Some(access);
+    pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
+        if let Some(access) = self.last_access.as_mut() {
+            access.set(path_id, version);
+        } else {
+            self.last_access = Some(Access::new(path_id, version));
+        }
     }
 }

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -133,8 +133,8 @@ impl Mutex {
 }
 
 impl State {
-    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(crate) fn for_each_last_dependent_access(&self, f: impl FnMut(&Access)) {
+        self.last_access.iter().for_each(f);
     }
 
     pub(crate) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -138,10 +138,6 @@ impl State {
     }
 
     pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
-        if let Some(access) = self.last_access.as_mut() {
-            access.set(path_id, version);
-        } else {
-            self.last_access = Some(Access::new(path_id, version));
-        }
+        Access::set_or_create(&mut self.last_access, path_id, version);
     }
 }

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -130,8 +130,8 @@ impl Notify {
 }
 
 impl State {
-    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(crate) fn for_each_last_dependent_access(&self, f: impl FnMut(&Access)) {
+        self.last_access.iter().for_each(f);
     }
 
     pub(crate) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, Access, Synchronize};
+use crate::rt::{self, Access, Synchronize, VersionVec};
 
 use std::sync::atomic::Ordering::{Acquire, Release};
 
@@ -134,7 +134,11 @@ impl State {
         self.last_access.iter().for_each(f);
     }
 
-    pub(crate) fn set_last_access(&mut self, access: Access) {
-        self.last_access = Some(access);
+    pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
+        if let Some(access) = self.last_access.as_mut() {
+            access.set(path_id, version);
+        } else {
+            self.last_access = Some(Access::new(path_id, version));
+        }
     }
 }

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -135,10 +135,6 @@ impl State {
     }
 
     pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
-        if let Some(access) = self.last_access.as_mut() {
-            access.set(path_id, version);
-        } else {
-            self.last_access = Some(Access::new(path_id, version));
-        }
+        Access::set_or_create(&mut self.last_access, path_id, version);
     }
 }

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,5 +1,5 @@
 use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify};
-use crate::rt::{Access, Execution};
+use crate::rt::{Access, VersionVec, Execution};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Object {
@@ -180,14 +180,21 @@ impl Store {
         }
     }
 
-    pub(super) fn set_last_access(&mut self, operation: Operation, access: Access) {
+    pub(super) fn set_last_access(
+        &mut self,
+        operation: Operation,
+        path_id: usize,
+        dpor_vv: &VersionVec,
+    ) {
         match &mut self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),
-            Entry::Arc(entry) => entry.set_last_access(operation.action.into(), access),
-            Entry::Atomic(entry) => entry.set_last_access(operation.action.into(), access),
-            Entry::Mutex(entry) => entry.set_last_access(access),
-            Entry::Condvar(entry) => entry.set_last_access(access),
-            Entry::Notify(entry) => entry.set_last_access(access),
+            Entry::Arc(entry) => {
+                entry.set_last_access(operation.action.into(), path_id, dpor_vv)
+            }
+            Entry::Atomic(entry) => entry.set_last_access(operation.action.into(), path_id, dpor_vv),
+            Entry::Mutex(entry) => entry.set_last_access(path_id, dpor_vv),
+            Entry::Condvar(entry) => entry.set_last_access(path_id, dpor_vv),
+            Entry::Notify(entry) => entry.set_last_access(path_id, dpor_vv),
         }
     }
 

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -165,17 +165,18 @@ impl Store {
         }
     }
 
-    pub(super) fn last_dependent_accesses<'a>(
-        &'a self,
+    pub(super) fn for_each_last_dependent_access(
+        &self,
         operation: Operation,
-    ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
+        f: impl FnMut(&Access),
+    ) {
         match &self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),
-            Entry::Arc(entry) => entry.last_dependent_accesses(operation.action.into()),
-            Entry::Atomic(entry) => entry.last_dependent_accesses(operation.action.into()),
-            Entry::Mutex(entry) => entry.last_dependent_accesses(),
-            Entry::Condvar(entry) => entry.last_dependent_accesses(),
-            Entry::Notify(entry) => entry.last_dependent_accesses(),
+            Entry::Arc(entry) => entry.for_each_last_dependent_access(operation.action.into(), f),
+            Entry::Atomic(entry) => entry.for_each_last_dependent_access(operation.action.into(), f),
+            Entry::Mutex(entry) => entry.for_each_last_dependent_access(f),
+            Entry::Condvar(entry) => entry.for_each_last_dependent_access(f),
+            Entry::Notify(entry) => entry.for_each_last_dependent_access(f),
         }
     }
 

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -294,16 +294,12 @@ impl Set {
             .map(move |(id, thread)| (Id::new(execution_id, id), thread))
     }
 
-    pub(crate) fn iter_mut<'a>(
-        &'a mut self,
-    ) -> Box<dyn Iterator<Item = (Id, &'a mut Thread)> + 'a> {
+    pub(crate) fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (Id, &'a mut Thread)> {
         let execution_id = self.execution_id;
-        Box::new({
-            self.threads
-                .iter_mut()
-                .enumerate()
-                .map(move |(id, thread)| (Id::new(execution_id, id), thread))
-        })
+        self.threads
+            .iter_mut()
+            .enumerate()
+            .map(move |(id, thread)| (Id::new(execution_id, id), thread))
     }
 
     /// Split the set of threads into the active thread and an iterator of all

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -20,6 +20,10 @@ impl VersionVec {
         }
     }
 
+    pub(crate) fn set(&mut self, other: &VersionVec) {
+        self.versions.copy_from_slice(&other.versions);
+    }
+
     pub(crate) fn versions<'a>(
         &'a self,
         execution_id: execution::Id,


### PR DESCRIPTION
A couple of small changes to reduce memory allocations:
* switch `last_dependent_accesses` to internal iteration to avoid boxing iterators
* reuse VersionVecs of last accesses

As a benchmark, with these changes running time of tokio-executor loom tests went down from 21.0s (with loom 0.2.12) to 16.6s on my machine.