### PR TITLE
Don't use iterators to get last dependent accesses

### DIFF
--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -121,14 +121,11 @@ impl State {
         assert_eq!(0, self.ref_cnt, "Arc leaked");
     }
 
-    pub(super) fn last_dependent_accesses<'a>(
-        &'a self,
-        action: Action,
-    ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
+    pub(super) fn last_dependent_access(&self, action: Action) -> Option<&Access> {
         match action {
             // RefIncs are not dependent w/ RefDec, only inspections
-            Action::RefInc => Box::new([].into_iter()),
-            Action::RefDec => Box::new(self.last_ref_dec.iter()),
+            Action::RefInc => None,
+            Action::RefDec => self.last_ref_dec.as_ref(),
         }
     }
 

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -86,8 +86,8 @@ impl Condvar {
 }
 
 impl State {
-    pub(super) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(super) fn last_dependent_access(&self) -> Option<&Access> {
+        self.last_access.as_ref()
     }
 
     pub(super) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -121,7 +121,7 @@ impl Execution {
                 None => continue,
             };
 
-            for access in self.objects.last_dependent_accesses(operation) {
+            if let Some(access) = self.objects.last_dependent_access(operation) {
                 if access.happens_before(&th.dpor_vv) {
                     // The previous access happened before this access, thus
                     // there is no race.
@@ -201,7 +201,7 @@ impl Execution {
             let threads = &mut self.threads;
             let th_id = threads.active_id();
 
-            for access in self.objects.last_dependent_accesses(operation) {
+            if let Some(access) = self.objects.last_dependent_access(operation) {
                 threads.active_mut().dpor_vv.join(access.version());
             }
 

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -133,8 +133,8 @@ impl Mutex {
 }
 
 impl State {
-    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(crate) fn last_dependent_access(&self) -> Option<&Access> {
+        self.last_access.as_ref()
     }
 
     pub(crate) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -130,8 +130,8 @@ impl Notify {
 }
 
 impl State {
-    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(crate) fn last_dependent_access(&self) -> Option<&Access> {
+        self.last_access.as_ref()
     }
 
     pub(crate) fn set_last_access(&mut self, access: Access) {

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -165,17 +165,14 @@ impl Store {
         }
     }
 
-    pub(super) fn last_dependent_accesses<'a>(
-        &'a self,
-        operation: Operation,
-    ) -> Box<dyn Iterator<Item = &'a Access> + 'a> {
+    pub(super) fn last_dependent_access(&self, operation: Operation) -> Option<&Access> {
         match &self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),
-            Entry::Arc(entry) => entry.last_dependent_accesses(operation.action.into()),
-            Entry::Atomic(entry) => entry.last_dependent_accesses(operation.action.into()),
-            Entry::Mutex(entry) => entry.last_dependent_accesses(),
-            Entry::Condvar(entry) => entry.last_dependent_accesses(),
-            Entry::Notify(entry) => entry.last_dependent_accesses(),
+            Entry::Arc(entry) => entry.last_dependent_access(operation.action.into()),
+            Entry::Atomic(entry) => entry.last_dependent_access(),
+            Entry::Mutex(entry) => entry.last_dependent_access(),
+            Entry::Condvar(entry) => entry.last_dependent_access(),
+            Entry::Notify(entry) => entry.last_dependent_access(),
         }
     }
 
@@ -183,7 +180,7 @@ impl Store {
         match &mut self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),
             Entry::Arc(entry) => entry.set_last_access(operation.action.into(), access),
-            Entry::Atomic(entry) => entry.set_last_access(operation.action.into(), access),
+            Entry::Atomic(entry) => entry.set_last_access(access),
             Entry::Mutex(entry) => entry.set_last_access(access),
             Entry::Condvar(entry) => entry.set_last_access(access),
             Entry::Notify(entry) => entry.set_last_access(access),


### PR DESCRIPTION
As per https://github.com/tokio-rs/loom/pull/94#discussion_r342879131, it is not really necessary to store load and store accesses for `Atomic` separately, so the method returning last dependent accesses for an operation can simply return an `Option`. This simplifies the code and gives a nice performance benefit by getting rid of iterator boxing.