### PR TITLE
Allocate runtime objects in a bump arena

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ futures = ["futures-util"]
 [dependencies]
 cfg-if = "0.1.6"
 scoped-tls = "0.1.2"
+bumpalo = "2.6.0"
 
 # Provides a generator based runtime
 generator = "0.6.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures = ["futures-util"]
 [dependencies]
 cfg-if = "0.1.6"
 scoped-tls = "0.1.2"
-bumpalo = "2.6.0"
+bumpalo = { version = "3.2.0", features = ["collections"] }
 
 # Provides a generator based runtime
 generator = "0.6.18"

--- a/src/cell/causal.rs
+++ b/src/cell/causal.rs
@@ -1,8 +1,6 @@
-use crate::rt::{self, VersionVec, VersionVecGen, VersionVecSlice};
+use crate::rt;
 
 use std::cell::UnsafeCell;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 /// CausalCell ensures access to the inner value are valid under the Rust memory
 /// model.
@@ -11,60 +9,21 @@ pub struct CausalCell<T> {
     data: UnsafeCell<T>,
 
     /// Causality associated with the cell
-    state: Arc<Mutex<State>>,
+    obj: rt::CausalCell,
 }
 
 /// Deferred causal cell check
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[must_use]
-pub struct CausalCheck {
-    deferred: Vec<(Arc<Mutex<State>>, usize)>,
-}
-
-#[derive(Debug)]
-struct State {
-    causality: Causality,
-    deferred: HashMap<usize, Deferred>,
-    next_index: usize,
-}
-
-#[derive(Debug)]
-struct Deferred {
-    /// True if a mutable access
-    is_mut: bool,
-
-    /// Thread causality at the point the access happened.
-    thread_causality: VersionVec,
-
-    /// Result
-    result: Result<(), String>,
-}
-
-#[derive(Debug, Clone)]
-struct Causality {
-    // The transitive closure of all immutable accessses of `data`.
-    immut_access_version: VersionVec,
-
-    // The last mutable access of `data`.
-    mut_access_version: VersionVec,
-}
+pub struct CausalCheck(rt::CausalCheck);
 
 impl<T> CausalCell<T> {
     /// Construct a new instance of `CausalCell` which will wrap the specified
     /// value.
     pub fn new(data: T) -> CausalCell<T> {
-        let v = rt::execution(|execution| execution.threads.active().causality.clone_box());
-
         CausalCell {
             data: UnsafeCell::new(data),
-            state: Arc::new(Mutex::new(State {
-                causality: Causality {
-                    immut_access_version: v.clone(),
-                    mut_access_version: v,
-                },
-                deferred: HashMap::new(),
-                next_index: 0,
-            })),
+            obj: rt::CausalCell::new(),
         }
     }
 
@@ -78,10 +37,7 @@ impl<T> CausalCell<T> {
     where
         F: FnOnce(*const T) -> R,
     {
-        rt::critical(|| {
-            self.check();
-            self.with_unchecked(f)
-        })
+        self.obj.with(f, self.data.get())
     }
 
     /// Get an immutable pointer to the wrapped value, deferring the causality
@@ -95,32 +51,8 @@ impl<T> CausalCell<T> {
     where
         F: FnOnce(*const T) -> R,
     {
-        rt::critical(|| {
-            rt::execution(|execution| {
-                let thread_causality = &execution.threads.active().causality;
-
-                let mut state = self.state.lock().unwrap();
-                let index = state.next_index;
-                let result = state.causality.check(thread_causality);
-
-                state.deferred.insert(
-                    index,
-                    Deferred {
-                        is_mut: false,
-                        thread_causality: thread_causality.clone_box(),
-                        result,
-                    },
-                );
-
-                state.next_index += 1;
-
-                let check = CausalCheck {
-                    deferred: vec![(self.state.clone(), index)],
-                };
-
-                (self.with_unchecked(f), check)
-            })
-        })
+        let (res, check) = self.obj.with_deferred(f, self.data.get());
+        (res, CausalCheck(check))
     }
 
     /// Get a mutable pointer to the wrapped value.
@@ -133,10 +65,7 @@ impl<T> CausalCell<T> {
     where
         F: FnOnce(*mut T) -> R,
     {
-        rt::critical(|| {
-            self.check_mut();
-            self.with_mut_unchecked(f)
-        })
+        self.obj.with_mut(f, self.data.get())
     }
 
     /// Get a mutable pointer to the wrapped value.
@@ -149,32 +78,8 @@ impl<T> CausalCell<T> {
     where
         F: FnOnce(*mut T) -> R,
     {
-        rt::critical(|| {
-            rt::execution(|execution| {
-                let thread_causality = &execution.threads.active().causality;
-
-                let mut state = self.state.lock().unwrap();
-                let index = state.next_index;
-                let result = state.causality.check_mut(thread_causality);
-
-                state.deferred.insert(
-                    index,
-                    Deferred {
-                        is_mut: true,
-                        thread_causality: thread_causality.clone_box(),
-                        result,
-                    },
-                );
-
-                state.next_index += 1;
-
-                let check = CausalCheck {
-                    deferred: vec![(self.state.clone(), index)],
-                };
-
-                (self.with_mut_unchecked(f), check)
-            })
-        })
+        let (res, check) = self.obj.with_deferred_mut(f, self.data.get());
+        (res, CausalCheck(check))
     }
 
     /// Get an immutable pointer to the wrapped value.
@@ -200,17 +105,7 @@ impl<T> CausalCell<T> {
     /// access with this immutable access, while allowing many concurrent
     /// immutable accesses.
     pub fn check(&self) {
-        rt::execution(|execution| {
-            let thread_causality = &execution.threads.active().causality;
-            let mut state = self.state.lock().unwrap();
-
-            state.causality.check(thread_causality).unwrap();
-            state.causality.immut_access_version.join(thread_causality);
-
-            for deferred in state.deferred.values_mut() {
-                deferred.check(thread_causality);
-            }
-        })
+        self.obj.check();
     }
 
     /// Check that the current thread can make a mutable access without violating
@@ -219,165 +114,18 @@ impl<T> CausalCell<T> {
     /// Specifically, this function checks that there is no concurrent mutable
     /// access and no concurrent immutable access(es) with this mutable access.
     pub fn check_mut(&self) {
-        rt::execution(|execution| {
-            let thread_causality = &execution.threads.active().causality;
-            let mut state = self.state.lock().unwrap();
-
-            state.causality.check_mut(thread_causality).unwrap();
-            state.causality.mut_access_version.join(thread_causality);
-
-            for deferred in state.deferred.values_mut() {
-                deferred.check_mut(thread_causality);
-            }
-        })
+        self.obj.check_mut();
     }
 }
 
 impl CausalCheck {
-    /// Panic if the CausaalCell access was invalid.
-    pub fn check(mut self) {
-        for (state, index) in self.deferred.drain(..) {
-            let mut state = state.lock().unwrap();
-            let deferred = state.deferred.remove(&index).unwrap();
-
-            // panic if the check failed
-            deferred.result.unwrap();
-
-            if deferred.is_mut {
-                state
-                    .causality
-                    .mut_access_version
-                    .join(&deferred.thread_causality);
-            } else {
-                state
-                    .causality
-                    .immut_access_version
-                    .join(&deferred.thread_causality);
-            }
-
-            // Validate all remaining deferred checks
-            for other in state.deferred.values_mut() {
-                if deferred.is_mut {
-                    other.check_mut(&deferred.thread_causality);
-                } else {
-                    other.check(&deferred.thread_causality);
-                }
-            }
-        }
+    /// Panic if the CausalCell access was invalid.
+    pub fn check(self) {
+        self.0.check();
     }
 
     /// Merge this check with another check
     pub fn join(&mut self, other: CausalCheck) {
-        self.deferred.extend(other.deferred.into_iter());
-    }
-}
-
-impl Default for CausalCheck {
-    fn default() -> CausalCheck {
-        CausalCheck { deferred: vec![] }
-    }
-}
-
-impl Causality {
-    fn check(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
-        // Check that there is no concurrent mutable access, i.e., the last
-        // mutable access must happen-before this immutable access.
-
-        // Negating the comparison as version vectors are not totally
-        // ordered.
-        if !(self.mut_access_version <= *thread_causality) {
-            let msg = format!(
-                "Causality violation: \
-                 Concurrent mutable access and immutable access(es): \
-                 cell.with: v={:?}; mut v: {:?}; thread={:?}",
-                self.immut_access_version, self.mut_access_version, thread_causality
-            );
-
-            return Err(msg);
-        }
-
-        Ok(())
-    }
-
-    fn check_mut(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
-        // Check that there is no concurrent mutable access, i.e., the last
-        // mutable access must happen-before this mutable access.
-
-        // Negating the comparison as version vectors are not totally
-        // ordered.
-        if !(self.mut_access_version <= *thread_causality) {
-            let msg = format!(
-                "Causality violation: \
-                 Concurrent mutable accesses: \
-                 cell.with_mut: v={:?}; mut v={:?}; thread={:?}",
-                self.immut_access_version, self.mut_access_version, thread_causality,
-            );
-
-            return Err(msg);
-        }
-
-        // Check that there are no concurrent immutable accesss, i.e., every
-        // immutable access must happen-before this mutable access.
-        //
-        // Negating the comparison as version vectors are not totally
-        // ordered.
-        if !(self.immut_access_version <= *thread_causality) {
-            let msg = format!(
-                "Causality violation: \
-                 Concurrent mutable access and immutable access(es): \
-                 cell.with_mut: v={:?}; mut v={:?}; thread={:?}",
-                self.immut_access_version, self.mut_access_version, thread_causality,
-            );
-
-            return Err(msg);
-        }
-
-        Ok(())
-    }
-}
-
-impl Deferred {
-    fn check<T>(&mut self, thread_causality: &VersionVecGen<T>)
-    where
-        T: std::ops::DerefMut<Target = [usize]>,
-    {
-        if self.result.is_err() {
-            return;
-        }
-
-        if !self.is_mut {
-            // Concurrent reads are fine
-            return;
-        }
-
-        // Mutable access w/ immutable access must not be concurrent
-        if self
-            .thread_causality
-            .partial_cmp(thread_causality)
-            .is_none()
-        {
-            self.result = Err(
-                "Causality violation: concurrent mutable access and immutable access(es)"
-                    .to_string(),
-            );
-        }
-    }
-
-    fn check_mut<T>(&mut self, thread_causality: &VersionVecGen<T>)
-    where
-        T: std::ops::DerefMut<Target = [usize]>,
-    {
-        if self.result.is_err() {
-            return;
-        }
-
-        // Mutable access w/ immutable access must not be concurrent
-        if self
-            .thread_causality
-            .partial_cmp(thread_causality)
-            .is_none()
-        {
-            self.result = Err("Causality violation: concurrent mutable accesses".to_string());
-        }
+        self.0.join(other.0);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -174,9 +174,10 @@ impl Builder {
             });
 
             execution.check_for_leaks();
-            drop(execution);
 
+            drop(execution);
             bump.reset();
+
             if !path.step() {
                 println!("Completed in {} iterations", i);
                 return;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Model concurrent programs.
 
-use crate::rt::{self, Path, Execution, Scheduler};
+use crate::rt::{self, Execution, Path, Scheduler};
 use bumpalo::Bump;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/model.rs
+++ b/src/model.rs
@@ -174,6 +174,7 @@ impl Builder {
             });
 
             execution.check_for_leaks();
+            drop(execution);
 
             bump.reset();
             if !path.step() {

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -1,25 +1,25 @@
-use crate::rt::VersionVecSlice;
+use crate::rt::VersionVec;
 use bumpalo::Bump;
 
 #[derive(Debug)]
 pub(crate) struct Access<'bump> {
     path_id: usize,
-    dpor_vv: VersionVecSlice<'bump>,
+    dpor_vv: VersionVec<'bump>,
 }
 
 impl<'bump> Access<'bump> {
     pub(crate) fn new(
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) -> Access<'bump> {
         Access {
             path_id,
-            dpor_vv: VersionVecSlice::clone_in(version, bump),
+            dpor_vv: VersionVec::clone_in(version, bump),
         }
     }
 
-    pub(crate) fn set(&mut self, path_id: usize, version: &VersionVecSlice<'_>) {
+    pub(crate) fn set(&mut self, path_id: usize, version: &VersionVec<'_>) {
         self.path_id = path_id;
         self.dpor_vv.set(version);
     }
@@ -27,7 +27,7 @@ impl<'bump> Access<'bump> {
     pub(crate) fn set_or_create_in(
         access: &mut Option<Self>,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         if let Some(access) = access.as_mut() {
@@ -42,11 +42,11 @@ impl<'bump> Access<'bump> {
         self.path_id
     }
 
-    pub(crate) fn version(&self) -> &VersionVecSlice<'_> {
+    pub(crate) fn version(&self) -> &VersionVec<'_> {
         &self.dpor_vv
     }
 
-    pub(crate) fn happens_before(&self, version: &VersionVecSlice<'_>) -> bool {
+    pub(crate) fn happens_before(&self, version: &VersionVec<'_>) -> bool {
         self.dpor_vv <= *version
     }
 }

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -15,7 +15,7 @@ impl<'bump> Access<'bump> {
     ) -> Access<'bump> {
         Access {
             path_id,
-            dpor_vv: VersionVec::clone_in(version, bump),
+            dpor_vv: version.clone_in(bump),
         }
     }
 

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -1,4 +1,4 @@
-use crate::rt::{VersionVec, VersionVecSlice};
+use crate::rt::VersionVecSlice;
 use bumpalo::Bump;
 
 #[derive(Debug)]
@@ -10,7 +10,7 @@ pub(crate) struct Access<'bump> {
 impl<'bump> Access<'bump> {
     pub(crate) fn new(
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) -> Access<'bump> {
         Access {
@@ -19,7 +19,7 @@ impl<'bump> Access<'bump> {
         }
     }
 
-    pub(crate) fn set(&mut self, path_id: usize, version: &VersionVec) {
+    pub(crate) fn set(&mut self, path_id: usize, version: &VersionVecSlice<'_>) {
         self.path_id = path_id;
         self.dpor_vv.set(version);
     }
@@ -27,7 +27,7 @@ impl<'bump> Access<'bump> {
     pub(crate) fn set_or_create_in(
         access: &mut Option<Self>,
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) {
         if let Some(access) = access.as_mut() {
@@ -46,7 +46,7 @@ impl<'bump> Access<'bump> {
         &self.dpor_vv
     }
 
-    pub(crate) fn happens_before(&self, version: &VersionVec) -> bool {
+    pub(crate) fn happens_before(&self, version: &VersionVecSlice<'_>) -> bool {
         self.dpor_vv <= *version
     }
 }

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -15,7 +15,7 @@ impl<'bump> Access<'bump> {
     ) -> Access<'bump> {
         Access {
             path_id,
-            dpor_vv: VersionVecSlice::clone_bump(version, bump),
+            dpor_vv: VersionVecSlice::clone_in(version, bump),
         }
     }
 

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -1,6 +1,6 @@
 #![allow(warnings)]
 use crate::rt::object::Object;
-use crate::rt::{self, Access, Synchronize, VersionVecSlice};
+use crate::rt::{self, Access, Synchronize, VersionVec};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -134,7 +134,7 @@ impl<'bump> State<'bump> {
         &mut self,
         action: Action,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         match action {

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -1,6 +1,6 @@
 #![allow(warnings)]
 use crate::rt::object::Object;
-use crate::rt::{self, Access, Synchronize, VersionVec};
+use crate::rt::{self, Access, Synchronize, VersionVecSlice};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -134,7 +134,7 @@ impl<'bump> State<'bump> {
         &mut self,
         action: Action,
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) {
         match action {

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -213,7 +213,7 @@ impl<'bump> State<'bump> {
 
         let mut new = Store {
             // Clone the previous sync in order to form a release sequence.
-            sync: self.history.stores[index].sync.clone_bump(bump),
+            sync: self.history.stores[index].sync.clone_in(bump),
             first_seen: FirstSeen::new(threads, bump),
             seq_cst: is_seq_cst(success),
         };

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::Object;
-use crate::rt::{self, thread, Access, Path, Synchronize, VersionVecSlice};
+use crate::rt::{self, thread, Access, Path, Synchronize, VersionVec};
 
 use bumpalo::{collections::vec::Vec as BumpVec, Bump};
 use std::sync::atomic::Ordering;
@@ -164,7 +164,7 @@ impl<'bump> State<'bump> {
     pub(super) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);
@@ -224,7 +224,7 @@ impl<'bump> State<'bump> {
         Ok(index)
     }
 
-    fn happens_before(&self, vv: &VersionVecSlice<'_>) {
+    fn happens_before(&self, vv: &VersionVec<'_>) {
         assert!({
             self.history
                 .stores

--- a/src/rt/causal.rs
+++ b/src/rt/causal.rs
@@ -1,4 +1,4 @@
-use super::{execution, critical, object, VersionVec};
+use super::{critical, execution, object, VersionVec};
 
 use std::collections::HashMap;
 
@@ -68,7 +68,7 @@ impl CausalCell {
         })
     }
 
-    pub(crate)  fn with_deferred<F, T, R>(&self, f: F, data: *const T) -> (R, CausalCheck)
+    pub(crate) fn with_deferred<F, T, R>(&self, f: F, data: *const T) -> (R, CausalCheck)
     where
         F: FnOnce(*const T) -> R,
     {
@@ -277,8 +277,7 @@ impl Default for CausalCheck {
 }
 
 impl Deferred<'_> {
-    fn check(&mut self, thread_causality: &VersionVec<'_>)
-    {
+    fn check(&mut self, thread_causality: &VersionVec<'_>) {
         if self.result.is_err() {
             return;
         }
@@ -301,8 +300,7 @@ impl Deferred<'_> {
         }
     }
 
-    fn check_mut(&mut self, thread_causality: &VersionVec<'_>)
-    {
+    fn check_mut(&mut self, thread_causality: &VersionVec<'_>) {
         if self.result.is_err() {
             return;
         }

--- a/src/rt/causal.rs
+++ b/src/rt/causal.rs
@@ -1,4 +1,4 @@
-use super::{execution, critical, object, VersionVecSlice};
+use super::{execution, critical, object, VersionVec};
 
 use std::collections::HashMap;
 
@@ -17,10 +17,10 @@ pub(crate) struct State<'bump> {
 #[derive(Debug)]
 struct Causality<'bump> {
     // The transitive closure of all immutable accessses of `data`.
-    immut_access_version: VersionVecSlice<'bump>,
+    immut_access_version: VersionVec<'bump>,
 
     // The last mutable access of `data`.
-    mut_access_version: VersionVecSlice<'bump>,
+    mut_access_version: VersionVec<'bump>,
 }
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ struct Deferred<'bump> {
     is_mut: bool,
 
     /// Thread causality at the point the access happened.
-    thread_causality: VersionVecSlice<'bump>,
+    thread_causality: VersionVec<'bump>,
 
     /// Result
     result: Result<(), String>,
@@ -172,7 +172,7 @@ impl CausalCell {
 }
 
 impl Causality<'_> {
-    fn check(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
+    fn check(&self, thread_causality: &VersionVec<'_>) -> Result<(), String> {
         // Check that there is no concurrent mutable access, i.e., the last
         // mutable access must happen-before this immutable access.
 
@@ -192,7 +192,7 @@ impl Causality<'_> {
         Ok(())
     }
 
-    fn check_mut(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
+    fn check_mut(&self, thread_causality: &VersionVec<'_>) -> Result<(), String> {
         // Check that there is no concurrent mutable access, i.e., the last
         // mutable access must happen-before this mutable access.
 
@@ -277,7 +277,7 @@ impl Default for CausalCheck {
 }
 
 impl Deferred<'_> {
-    fn check(&mut self, thread_causality: &VersionVecSlice<'_>)
+    fn check(&mut self, thread_causality: &VersionVec<'_>)
     {
         if self.result.is_err() {
             return;
@@ -301,7 +301,7 @@ impl Deferred<'_> {
         }
     }
 
-    fn check_mut(&mut self, thread_causality: &VersionVecSlice<'_>)
+    fn check_mut(&mut self, thread_causality: &VersionVec<'_>)
     {
         if self.result.is_err() {
             return;

--- a/src/rt/causal.rs
+++ b/src/rt/causal.rs
@@ -1,0 +1,319 @@
+use super::{execution, critical, object, VersionVecSlice};
+
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub(crate) struct CausalCell {
+    obj_ref: object::CausalCellRef,
+}
+
+#[derive(Debug)]
+pub(crate) struct State<'bump> {
+    causality: Causality<'bump>,
+    deferred: HashMap<usize, Deferred<'bump>>,
+    next_index: usize,
+}
+
+#[derive(Debug)]
+struct Causality<'bump> {
+    // The transitive closure of all immutable accessses of `data`.
+    immut_access_version: VersionVecSlice<'bump>,
+
+    // The last mutable access of `data`.
+    mut_access_version: VersionVecSlice<'bump>,
+}
+
+#[derive(Debug)]
+pub struct CausalCheck {
+    deferred: Vec<(object::CausalCellRef, usize)>,
+}
+
+#[derive(Debug)]
+struct Deferred<'bump> {
+    /// True if a mutable access
+    is_mut: bool,
+
+    /// Thread causality at the point the access happened.
+    thread_causality: VersionVecSlice<'bump>,
+
+    /// Result
+    result: Result<(), String>,
+}
+
+impl CausalCell {
+    /// Construct a new instance of `CausalCell` which will wrap the specified
+    /// value.
+    pub(crate) fn new() -> CausalCell {
+        execution(|execution| {
+            let v = &execution.threads.active().causality;
+            let obj_ref = execution.objects.insert_causal_cell(State {
+                causality: Causality {
+                    immut_access_version: v.clone_in(execution.bump),
+                    mut_access_version: v.clone_in(execution.bump),
+                },
+                deferred: HashMap::new(),
+                next_index: 0,
+            });
+            CausalCell { obj_ref }
+        })
+    }
+
+    pub fn with<F, T, R>(&self, f: F, data: *const T) -> R
+    where
+        F: FnOnce(*const T) -> R,
+    {
+        critical(|| {
+            self.check();
+            f(data)
+        })
+    }
+
+    pub(crate)  fn with_deferred<F, T, R>(&self, f: F, data: *const T) -> (R, CausalCheck)
+    where
+        F: FnOnce(*const T) -> R,
+    {
+        critical(|| {
+            execution(|execution| {
+                let state = self.obj_ref.get_mut(&mut execution.objects);
+                let thread_causality = &execution.threads.active().causality;
+
+                let index = state.next_index;
+                let result = state.causality.check(thread_causality);
+
+                state.deferred.insert(
+                    index,
+                    Deferred {
+                        is_mut: false,
+                        thread_causality: thread_causality.clone_in(execution.bump),
+                        result,
+                    },
+                );
+
+                state.next_index += 1;
+
+                let check = CausalCheck {
+                    deferred: vec![(self.obj_ref.clone(), index)],
+                };
+
+                (f(data), check)
+            })
+        })
+    }
+
+    pub fn with_mut<F, T, R>(&self, f: F, data: *mut T) -> R
+    where
+        F: FnOnce(*mut T) -> R,
+    {
+        critical(|| {
+            self.check_mut();
+            f(data)
+        })
+    }
+
+    pub fn with_deferred_mut<F, T, R>(&self, f: F, data: *mut T) -> (R, CausalCheck)
+    where
+        F: FnOnce(*mut T) -> R,
+    {
+        critical(|| {
+            execution(|execution| {
+                let state = self.obj_ref.get_mut(&mut execution.objects);
+                let thread_causality = &execution.threads.active().causality;
+
+                let index = state.next_index;
+                let result = state.causality.check_mut(thread_causality);
+
+                state.deferred.insert(
+                    index,
+                    Deferred {
+                        is_mut: true,
+                        thread_causality: thread_causality.clone_in(execution.bump),
+                        result,
+                    },
+                );
+
+                state.next_index += 1;
+
+                let check = CausalCheck {
+                    deferred: vec![(self.obj_ref.clone(), index)],
+                };
+
+                (f(data), check)
+            })
+        })
+    }
+
+    pub(crate) fn check(&self) {
+        execution(|execution| {
+            let state = self.obj_ref.get_mut(&mut execution.objects);
+            let thread_causality = &execution.threads.active().causality;
+
+            state.causality.check(thread_causality).unwrap();
+            state.causality.immut_access_version.join(thread_causality);
+
+            for deferred in state.deferred.values_mut() {
+                deferred.check(thread_causality);
+            }
+        })
+    }
+
+    pub fn check_mut(&self) {
+        execution(|execution| {
+            let state = self.obj_ref.get_mut(&mut execution.objects);
+            let thread_causality = &execution.threads.active().causality;
+
+            state.causality.check_mut(thread_causality).unwrap();
+            state.causality.mut_access_version.join(thread_causality);
+
+            for deferred in state.deferred.values_mut() {
+                deferred.check_mut(thread_causality);
+            }
+        })
+    }
+}
+
+impl Causality<'_> {
+    fn check(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
+        // Check that there is no concurrent mutable access, i.e., the last
+        // mutable access must happen-before this immutable access.
+
+        // Negating the comparison as version vectors are not totally
+        // ordered.
+        if !(self.mut_access_version <= *thread_causality) {
+            let msg = format!(
+                "Causality violation: \
+                 Concurrent mutable access and immutable access(es): \
+                 cell.with: v={:?}; mut v: {:?}; thread={:?}",
+                self.immut_access_version, self.mut_access_version, thread_causality
+            );
+
+            return Err(msg);
+        }
+
+        Ok(())
+    }
+
+    fn check_mut(&self, thread_causality: &VersionVecSlice<'_>) -> Result<(), String> {
+        // Check that there is no concurrent mutable access, i.e., the last
+        // mutable access must happen-before this mutable access.
+
+        // Negating the comparison as version vectors are not totally
+        // ordered.
+        if !(self.mut_access_version <= *thread_causality) {
+            let msg = format!(
+                "Causality violation: \
+                 Concurrent mutable accesses: \
+                 cell.with_mut: v={:?}; mut v={:?}; thread={:?}",
+                self.immut_access_version, self.mut_access_version, thread_causality,
+            );
+
+            return Err(msg);
+        }
+
+        // Check that there are no concurrent immutable accesss, i.e., every
+        // immutable access must happen-before this mutable access.
+        //
+        // Negating the comparison as version vectors are not totally
+        // ordered.
+        if !(self.immut_access_version <= *thread_causality) {
+            let msg = format!(
+                "Causality violation: \
+                 Concurrent mutable access and immutable access(es): \
+                 cell.with_mut: v={:?}; mut v={:?}; thread={:?}",
+                self.immut_access_version, self.mut_access_version, thread_causality,
+            );
+
+            return Err(msg);
+        }
+
+        Ok(())
+    }
+}
+
+impl CausalCheck {
+    /// Panic if the CausalCell access was invalid.
+    pub fn check(mut self) {
+        execution(|execution| {
+            for (state_ref, index) in self.deferred.drain(..) {
+                let state = state_ref.get_mut(&mut execution.objects);
+                let deferred = state.deferred.remove(&index).unwrap();
+
+                // panic if the check failed
+                deferred.result.unwrap();
+
+                if deferred.is_mut {
+                    state
+                        .causality
+                        .mut_access_version
+                        .join(&deferred.thread_causality);
+                } else {
+                    state
+                        .causality
+                        .immut_access_version
+                        .join(&deferred.thread_causality);
+                }
+
+                // Validate all remaining deferred checks
+                for other in state.deferred.values_mut() {
+                    if deferred.is_mut {
+                        other.check_mut(&deferred.thread_causality);
+                    } else {
+                        other.check(&deferred.thread_causality);
+                    }
+                }
+            }
+        })
+    }
+
+    /// Merge this check with another check
+    pub fn join(&mut self, other: CausalCheck) {
+        self.deferred.extend(other.deferred.into_iter());
+    }
+}
+
+impl Default for CausalCheck {
+    fn default() -> CausalCheck {
+        CausalCheck { deferred: vec![] }
+    }
+}
+
+impl Deferred<'_> {
+    fn check(&mut self, thread_causality: &VersionVecSlice<'_>)
+    {
+        if self.result.is_err() {
+            return;
+        }
+
+        if !self.is_mut {
+            // Concurrent reads are fine
+            return;
+        }
+
+        // Mutable access w/ immutable access must not be concurrent
+        if self
+            .thread_causality
+            .partial_cmp(thread_causality)
+            .is_none()
+        {
+            self.result = Err(
+                "Causality violation: concurrent mutable access and immutable access(es)"
+                    .to_string(),
+            );
+        }
+    }
+
+    fn check_mut(&mut self, thread_causality: &VersionVecSlice<'_>)
+    {
+        if self.result.is_err() {
+            return;
+        }
+
+        // Mutable access w/ immutable access must not be concurrent
+        if self
+            .thread_causality
+            .partial_cmp(thread_causality)
+            .is_none()
+        {
+            self.result = Err("Causality violation: concurrent mutable accesses".to_string());
+        }
+    }
+}

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -80,7 +80,7 @@ impl Condvar {
         })
     }
 
-    fn get_state<'a>(&self, store: &'a mut object::Store) -> &'a mut State {
+    fn get_state<'a>(&self, store: &'a mut object::Store<'_>) -> &'a mut State {
         self.obj.condvar_mut(store).unwrap()
     }
 }

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, thread, Access, Mutex, VersionVec};
+use crate::rt::{self, thread, Access, Mutex, VersionVecSlice};
 
 use bumpalo::Bump;
 use std::collections::VecDeque;
@@ -94,7 +94,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, thread, Access, Mutex, VersionVecSlice};
+use crate::rt::{self, thread, Access, Mutex, VersionVec};
 
 use bumpalo::Bump;
 use std::collections::VecDeque;
@@ -94,7 +94,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/condvar.rs
+++ b/src/rt/condvar.rs
@@ -15,7 +15,7 @@ pub(super) struct State<'bump> {
     last_access: Option<Access<'bump>>,
 
     /// Threads waiting on the condvar
-    waiters: VecDeque<thread::Id>,
+    pub(crate) waiters: VecDeque<thread::Id>,
 }
 
 impl Condvar {

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -33,10 +33,7 @@ pub(crate) struct Execution<'bump> {
 pub(crate) struct Id(usize);
 
 impl<'bump> Execution<'bump> {
-    /// Create a new execution.
-    ///
-    /// This is only called at the start of a fuzz run. The same instance is
-    /// reused across permutations.
+    /// Create a new execution at the start of each iteration
     pub(crate) fn new(max_threads: usize, path: &'bump mut Path, bump: &'bump Bump) -> Self {
         let id = Id::new();
         let threads = thread::Set::new(id, max_threads, bump);

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -35,16 +35,16 @@ pub(crate) struct Execution<'a> {
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub(crate) struct Id(usize);
 
-impl Execution<'_> {
+impl<'bump> Execution<'bump> {
     /// Create a new execution.
     ///
     /// This is only called at the start of a fuzz run. The same instance is
     /// reused across permutations.
-    pub(crate) fn new<'a>(
+    pub(crate) fn new(
         max_threads: usize,
-        path: &'a mut Path,
-        bump: &'a Bump,
-    ) -> Execution<'a> {
+        path: &'bump mut Path,
+        bump: &'bump Bump,
+    ) -> Self {
         let id = Id::new();
         let threads = thread::Set::new(id, max_threads);
 

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -2,23 +2,22 @@ use crate::rt::alloc::Allocation;
 use crate::rt::{object, thread, Path};
 
 use bumpalo::Bump;
-
 use std::collections::HashMap;
 use std::fmt;
 
-pub(crate) struct Execution<'a> {
+pub(crate) struct Execution<'bump> {
     /// Uniquely identifies an execution
     pub(super) id: Id,
 
     /// Execution path taken
-    pub(crate) path: &'a mut Path,
+    pub(crate) path: &'bump mut Path,
 
-    pub(crate) bump: &'a Bump,
+    pub(crate) bump: &'bump Bump,
 
-    pub(crate) threads: thread::Set<'a>,
+    pub(crate) threads: thread::Set<'bump>,
 
     /// All loom aware objects part of this execution run.
-    pub(super) objects: object::Store<'a>,
+    pub(super) objects: object::Store<'bump>,
 
     /// Maps raw allocations to LeakTrack objects
     pub(super) raw_allocations: HashMap<usize, Allocation>,
@@ -26,7 +25,6 @@ pub(crate) struct Execution<'a> {
     /// Maximum number of concurrent threads
     pub(super) max_threads: usize,
 
-    // pub(super) max_history: usize,
     /// Log execution output to STDOUT
     pub(crate) log: bool,
 }

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -27,7 +27,6 @@ pub(crate) struct Execution<'a> {
     pub(super) max_threads: usize,
 
     // pub(super) max_history: usize,
-
     /// Log execution output to STDOUT
     pub(crate) log: bool,
 }
@@ -40,11 +39,7 @@ impl<'bump> Execution<'bump> {
     ///
     /// This is only called at the start of a fuzz run. The same instance is
     /// reused across permutations.
-    pub(crate) fn new(
-        max_threads: usize,
-        path: &'bump mut Path,
-        bump: &'bump Bump,
-    ) -> Self {
+    pub(crate) fn new(max_threads: usize, path: &'bump mut Path, bump: &'bump Bump) -> Self {
         let id = Id::new();
         let threads = thread::Set::new(id, max_threads, bump);
 

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -13,6 +13,8 @@ pub(crate) struct Execution<'a> {
     /// Execution path taken
     pub(crate) path: &'a mut Path,
 
+    pub(crate) bump: &'a Bump,
+
     pub(crate) threads: thread::Set,
 
     /// All loom aware objects part of this execution run.
@@ -49,6 +51,7 @@ impl Execution<'_> {
         Execution {
             id,
             path,
+            bump,
             threads,
             objects: object::Store::new(id, bump),
             raw_allocations: HashMap::new(),

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -15,7 +15,7 @@ pub(crate) struct Execution<'a> {
 
     pub(crate) bump: &'a Bump,
 
-    pub(crate) threads: thread::Set,
+    pub(crate) threads: thread::Set<'a>,
 
     /// All loom aware objects part of this execution run.
     pub(super) objects: object::Store<'a>,
@@ -46,7 +46,7 @@ impl<'bump> Execution<'bump> {
         bump: &'bump Bump,
     ) -> Self {
         let id = Id::new();
-        let threads = thread::Set::new(id, max_threads);
+        let threads = thread::Set::new(id, max_threads, bump);
 
         Execution {
             id,

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -24,6 +24,9 @@ pub(crate) mod object;
 mod mutex;
 pub(crate) use self::mutex::Mutex;
 
+mod causal;
+pub(crate) use self::causal::{CausalCell, CausalCheck};
+
 mod path;
 pub(crate) use self::path::Path;
 
@@ -36,7 +39,7 @@ pub(crate) use self::synchronize::Synchronize;
 pub(crate) mod thread;
 
 mod vv;
-pub(crate) use self::vv::{VersionVec, VersionVecGen, VersionVecSlice};
+pub(crate) use self::vv::VersionVecSlice;
 
 pub fn spawn<F>(f: F)
 where

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -66,7 +66,7 @@ pub fn park() {
 /// Add an execution branch point.
 fn branch<F, R>(f: F) -> R
 where
-    F: FnOnce(&mut Execution) -> R,
+    F: FnOnce(&mut Execution<'_>) -> R,
 {
     let (ret, switch) = execution(|execution| {
         let ret = f(execution);
@@ -82,7 +82,7 @@ where
 
 fn synchronize<F, R>(f: F) -> R
 where
-    F: FnOnce(&mut Execution) -> R,
+    F: FnOnce(&mut Execution<'_>) -> R,
 {
     execution(|execution| {
         let ret = f(execution);
@@ -133,7 +133,7 @@ where
 
 pub(crate) fn execution<F, R>(f: F) -> R
 where
-    F: FnOnce(&mut Execution) -> R,
+    F: FnOnce(&mut Execution<'_>) -> R,
 {
     Scheduler::with_execution(f)
 }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use self::synchronize::Synchronize;
 pub(crate) mod thread;
 
 mod vv;
-pub(crate) use self::vv::VersionVecSlice;
+pub(crate) use self::vv::VersionVec;
 
 pub fn spawn<F>(f: F)
 where

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use self::synchronize::Synchronize;
 pub(crate) mod thread;
 
 mod vv;
-pub(crate) use self::vv::{VersionVec, VersionVecSlice, VersionVecGen};
+pub(crate) use self::vv::{VersionVec, VersionVecGen, VersionVecSlice};
 
 pub fn spawn<F>(f: F)
 where

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use self::synchronize::Synchronize;
 pub(crate) mod thread;
 
 mod vv;
-pub(crate) use self::vv::{VersionVec, VersionVecSlice};
+pub(crate) use self::vv::{VersionVec, VersionVecSlice, VersionVecGen};
 
 pub fn spawn<F>(f: F)
 where

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use self::synchronize::Synchronize;
 pub(crate) mod thread;
 
 mod vv;
-pub(crate) use self::vv::VersionVec;
+pub(crate) use self::vv::{VersionVec, VersionVecSlice};
 
 pub fn spawn<F>(f: F)
 where

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{thread, Access, Synchronize, VersionVec};
+use crate::rt::{thread, Access, Synchronize, VersionVecSlice};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -141,7 +141,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -1,6 +1,7 @@
 use crate::rt::object::{self, Object};
 use crate::rt::{thread, Access, Synchronize, VersionVec};
 
+use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -18,7 +19,7 @@ pub(super) struct State<'bump> {
     lock: Option<thread::Id>,
 
     /// Tracks access to the mutex
-    last_access: Option<Access>,
+    last_access: Option<Access<'bump>>,
 
     /// Causality transfers between threads
     synchronize: Synchronize<'bump>,
@@ -127,17 +128,22 @@ impl Mutex {
         super::execution(|execution| self.get_state(&mut execution.objects).lock.is_some())
     }
 
-    fn get_state<'a, 'b>(&self, objects: &'a mut object::Store<'b>) -> &'a mut State<'b> {
+    fn get_state<'a, 'bump>(&self, objects: &'a mut object::Store<'bump>) -> &'a mut State<'bump> {
         self.obj.mutex_mut(objects).unwrap()
     }
 }
 
-impl State<'_> {
-    pub(crate) fn last_dependent_access(&self) -> Option<&Access> {
+impl<'bump> State<'bump> {
+    pub(crate) fn last_dependent_access(&self) -> Option<&Access<'bump>> {
         self.last_access.as_ref()
     }
 
-    pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
-        Access::set_or_create(&mut self.last_access, path_id, version);
+    pub(crate) fn set_last_access(
+        &mut self,
+        path_id: usize,
+        version: &VersionVec,
+        bump: &'bump Bump,
+    ) {
+        Access::set_or_create_in(&mut self.last_access, path_id, version, bump);
     }
 }

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -127,7 +127,7 @@ impl Mutex {
         super::execution(|execution| self.get_state(&mut execution.objects).lock.is_some())
     }
 
-    fn get_state<'a>(&self, objects: &'a mut object::Store) -> &'a mut State {
+    fn get_state<'a>(&self, objects: &'a mut object::Store<'_>) -> &'a mut State {
         self.obj.mutex_mut(objects).unwrap()
     }
 }

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{thread, Access, Synchronize, VersionVecSlice};
+use crate::rt::{thread, Access, Synchronize, VersionVec};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -141,7 +141,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, Access, Synchronize, VersionVecSlice};
+use crate::rt::{self, Access, Synchronize, VersionVec};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -138,7 +138,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVecSlice<'_>,
+        version: &VersionVec<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -1,5 +1,5 @@
 use crate::rt::object::{self, Object};
-use crate::rt::{self, Access, Synchronize, VersionVec};
+use crate::rt::{self, Access, Synchronize, VersionVecSlice};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{Acquire, Release};
@@ -138,7 +138,7 @@ impl<'bump> State<'bump> {
     pub(crate) fn set_last_access(
         &mut self,
         path_id: usize,
-        version: &VersionVec,
+        version: &VersionVecSlice<'_>,
         bump: &'bump Bump,
     ) {
         Access::set_or_create_in(&mut self.last_access, path_id, version, bump);

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -124,7 +124,7 @@ impl Notify {
         });
     }
 
-    fn get_state<'a>(self, store: &'a mut object::Store) -> &'a mut State {
+    fn get_state<'a>(self, store: &'a mut object::Store<'_>) -> &'a mut State {
         self.obj.notify_mut(store).unwrap()
     }
 }

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,5 +1,5 @@
 use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify, causal};
-use crate::rt::{Access, Execution, VersionVecSlice};
+use crate::rt::{Access, Execution, VersionVec};
 use bumpalo::{collections::vec::Vec as BumpVec, Bump};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -240,7 +240,7 @@ impl<'bump> Store<'bump> {
         &mut self,
         operation: Operation,
         path_id: usize,
-        dpor_vv: &VersionVecSlice<'_>,
+        dpor_vv: &VersionVec<'_>,
     ) {
         match &mut self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,4 +1,4 @@
-use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify, causal};
+use crate::rt::{alloc, arc, atomic, causal, condvar, execution, mutex, notify};
 use crate::rt::{Access, Execution, VersionVec};
 use bumpalo::{collections::vec::Vec as BumpVec, Bump};
 
@@ -13,7 +13,7 @@ pub struct Object {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct CausalCellRef {
-    /// Index in the causal_cells vec.
+    /// Index in the causal_cells vec
     index: usize,
 
     /// Execution the object is part of
@@ -29,9 +29,10 @@ pub struct Store<'bump> {
     /// Stored state for all objects.
     entries: BumpVec<'bump, Entry<'bump>>,
 
+    /// Stored state for CausalCells
     causal_cells: BumpVec<'bump, causal::State<'bump>>,
 
-    /// Bump allocator.
+    /// Bump allocator
     bump: &'bump Bump,
 }
 

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,6 +1,6 @@
 use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify};
 use crate::rt::{Access, Execution, VersionVecSlice};
-use bumpalo::{Bump, collections::vec::Vec as BumpVec};
+use bumpalo::{collections::vec::Vec as BumpVec, Bump};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Object {

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -192,9 +192,9 @@ impl Store {
         }
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.entries.clear();
-    }
+    // pub(crate) fn clear(&mut self) {
+    //     self.entries.clear();
+    // }
 
     /// Panics if any leaks were detected
     pub(crate) fn check_for_leaks(&self) {
@@ -231,7 +231,7 @@ impl Object {
         self.branch(Action::Opaque)
     }
 
-    fn set_action(self, execution: &mut Execution, action: Action) {
+    fn set_action(self, execution: &mut Execution<'_>, action: Action) {
         execution.threads.active_mut().operation = Some(Operation { obj: self, action });
     }
 }

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,5 +1,5 @@
 use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify};
-use crate::rt::{Access, Execution, VersionVec};
+use crate::rt::{Access, Execution, VersionVecSlice};
 use bumpalo::{Bump, collections::vec::Vec as BumpVec};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -207,7 +207,7 @@ impl<'bump> Store<'bump> {
         &mut self,
         operation: Operation,
         path_id: usize,
-        dpor_vv: &VersionVec,
+        dpor_vv: &VersionVecSlice<'_>,
     ) {
         match &mut self.entries[operation.obj.index] {
             Entry::Alloc(_) => panic!("allocations are not branchable operations"),

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -126,6 +126,8 @@ fn spawn_threads(n: usize) -> Vec<Thread> {
         .collect()
 }
 
-unsafe fn transmute_lt<'a>(state: &'a RefCell<State<'_, '_>>) -> &'a RefCell<State<'static, 'static>> {
+unsafe fn transmute_lt<'a>(
+    state: &'a RefCell<State<'_, '_>>,
+) -> &'a RefCell<State<'static, 'static>> {
     ::std::mem::transmute(state)
 }

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -31,7 +31,7 @@ impl<'bump> Synchronize<'bump> {
         &self.happens_before
     }
 
-    pub fn sync_load(&mut self, threads: &mut thread::Set, order: Ordering) {
+    pub fn sync_load(&mut self, threads: &mut thread::Set<'_>, order: Ordering) {
         match order {
             Relaxed | Release => {
                 // Nothing happens!
@@ -47,7 +47,7 @@ impl<'bump> Synchronize<'bump> {
         }
     }
 
-    pub fn sync_store(&mut self, threads: &mut thread::Set, order: Ordering) {
+    pub fn sync_store(&mut self, threads: &mut thread::Set<'_>, order: Ordering) {
         match order {
             Relaxed | Acquire => {
                 // Nothing happens!
@@ -63,11 +63,11 @@ impl<'bump> Synchronize<'bump> {
         }
     }
 
-    fn sync_acq(&mut self, threads: &mut thread::Set) {
+    fn sync_acq(&mut self, threads: &mut thread::Set<'_>) {
         threads.active_mut().causality.join(&self.happens_before);
     }
 
-    fn sync_rel(&mut self, threads: &thread::Set) {
+    fn sync_rel(&mut self, threads: &thread::Set<'_>) {
         self.happens_before.join(&threads.active().causality);
     }
 }

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -1,4 +1,4 @@
-use crate::rt::{thread, VersionVecSlice};
+use crate::rt::{thread, VersionVec};
 
 use bumpalo::Bump;
 use std::sync::atomic::Ordering::{self, *};
@@ -11,12 +11,12 @@ use std::sync::atomic::Ordering::{self, *};
 /// updated with the threads.
 #[derive(Debug)]
 pub(crate) struct Synchronize<'bump> {
-    happens_before: VersionVecSlice<'bump>,
+    happens_before: VersionVec<'bump>,
 }
 
 impl<'bump> Synchronize<'bump> {
     pub fn new(max_threads: usize, bump: &'bump Bump) -> Self {
-        let happens_before = VersionVecSlice::new_bump(max_threads, bump);
+        let happens_before = VersionVec::new_in(max_threads, bump);
 
         Synchronize { happens_before }
     }
@@ -27,7 +27,7 @@ impl<'bump> Synchronize<'bump> {
         res
     }
 
-    pub fn version_vec(&self) -> &VersionVecSlice<'_> {
+    pub fn version_vec(&self) -> &VersionVec<'_> {
         &self.happens_before
     }
 

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -21,7 +21,7 @@ impl<'bump> Synchronize<'bump> {
         Synchronize { happens_before }
     }
 
-    pub fn clone_bump(&self, bump: &'bump Bump) -> Self {
+    pub fn clone_in(&self, bump: &'bump Bump) -> Self {
         let mut res = Self::new(self.happens_before.len(), bump);
         res.happens_before.set(&self.happens_before);
         res

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -274,17 +274,17 @@ impl Set {
             .join(&self.threads[self.active.unwrap()].causality);
     }
 
-    pub(crate) fn clear(&mut self, execution_id: execution::Id) {
-        self.threads.clear();
-        self.threads.push(Thread::new(
-            Id::new(execution_id, 0),
-            self.threads.capacity(),
-        ));
+    // pub(crate) fn clear(&mut self, execution_id: execution::Id) {
+    //     self.threads.clear();
+    //     self.threads.push(Thread::new(
+    //         Id::new(execution_id, 0),
+    //         self.threads.capacity(),
+    //     ));
 
-        self.execution_id = execution_id;
-        self.active = Some(0);
-        self.seq_cst_causality = VersionVec::new(self.max());
-    }
+    //     self.execution_id = execution_id;
+    //     self.active = Some(0);
+    //     self.seq_cst_causality = VersionVec::new(self.max());
+    // }
 
     pub(crate) fn iter<'a>(&'a self) -> impl Iterator<Item = (Id, &'a Thread)> + 'a {
         let execution_id = self.execution_id;

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -286,18 +286,6 @@ impl<'bump> Set<'bump> {
             .join(&self.threads[self.active.unwrap()].causality);
     }
 
-    // pub(crate) fn clear(&mut self, execution_id: execution::Id) {
-    //     self.threads.clear();
-    //     self.threads.push(Thread::new(
-    //         Id::new(execution_id, 0),
-    //         self.threads.capacity(),
-    //     ));
-
-    //     self.execution_id = execution_id;
-    //     self.active = Some(0);
-    //     self.seq_cst_causality = VersionVec::new(self.max());
-    // }
-
     pub(crate) fn iter<'a>(&'a self) -> impl Iterator<Item = (Id, &'a Thread<'_>)> + 'a {
         let execution_id = self.execution_id;
         self.threads

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -1,6 +1,6 @@
 use crate::rt::execution;
 use crate::rt::object::Operation;
-use crate::rt::vv::VersionVecSlice;
+use crate::rt::vv::VersionVec;
 
 use bumpalo::Bump;
 use std::{any::Any, collections::HashMap, fmt, ops};
@@ -18,10 +18,10 @@ pub(crate) struct Thread<'bump> {
     pub(super) operation: Option<Operation>,
 
     /// Tracks observed causality
-    pub causality: VersionVecSlice<'bump>,
+    pub causality: VersionVec<'bump>,
 
     /// Tracks DPOR relations
-    pub dpor_vv: VersionVecSlice<'bump>,
+    pub dpor_vv: VersionVec<'bump>,
 
     /// Version at which the thread last yielded
     pub last_yield: Option<usize>,
@@ -47,7 +47,7 @@ pub(crate) struct Set<'bump> {
 
     /// Sequential consistency causality. All sequentially consistent operations
     /// synchronize with this causality.
-    pub seq_cst_causality: VersionVecSlice<'bump>,
+    pub seq_cst_causality: VersionVec<'bump>,
 
     bump: &'bump Bump,
 }
@@ -80,8 +80,8 @@ impl<'bump> Thread<'bump> {
             state: State::Runnable,
             critical: false,
             operation: None,
-            causality: VersionVecSlice::new_bump(max_threads, bump),
-            dpor_vv: VersionVecSlice::new_bump(max_threads, bump),
+            causality: VersionVec::new_in(max_threads, bump),
+            dpor_vv: VersionVec::new_in(max_threads, bump),
             last_yield: None,
             yield_count: 0,
             locals: HashMap::new(),
@@ -190,7 +190,7 @@ impl<'bump> Set<'bump> {
             execution_id,
             threads,
             active: Some(0),
-            seq_cst_causality: VersionVecSlice::new_bump(max_threads, bump),
+            seq_cst_causality: VersionVec::new_in(max_threads, bump),
             bump,
         }
     }

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -12,7 +12,6 @@ pub(crate) struct VersionVecGen<T: ops::DerefMut<Target = [usize]>> {
     versions: T,
 }
 
-pub(crate) type VersionVec = VersionVecGen<Box<[usize]>>;
 pub(crate) type VersionVecSlice<'a> = VersionVecGen<&'a mut [usize]>;
 
 impl<T: ops::DerefMut<Target = [usize]>> VersionVecGen<T> {
@@ -36,15 +35,9 @@ impl<T: ops::DerefMut<Target = [usize]>> VersionVecGen<T> {
         }
     }
 
-    pub(crate) fn clone_bump<'bump>(&self, bump: &'bump Bump) -> VersionVecSlice<'bump> {
+    pub(crate) fn clone_in<'bump>(&self, bump: &'bump Bump) -> VersionVecSlice<'bump> {
         VersionVecSlice {
             versions: bump.alloc_slice_copy(&self.versions),
-        }
-    }
-
-    pub(crate) fn clone_box(&self) -> VersionVec {
-        VersionVec {
-            versions: (&*self.versions).into(),
         }
     }
 

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -11,26 +11,8 @@ pub(crate) struct VersionVec<'bump> {
 
 impl VersionVec<'_> {
     pub(crate) fn new_in(max_threads: usize, bump: &Bump) -> VersionVec<'_> {
-        // TODO: use method provided by Bump when https://github.com/fitzgen/bumpalo/issues/41
-        // gets done.
-        let layout = std::alloc::Layout::from_size_align(
-            std::mem::size_of::<usize>()
-                .checked_mul(max_threads)
-                .unwrap(),
-            std::mem::align_of::<usize>(),
-        )
-        .unwrap();
-
-        let ptr = bump.alloc_layout(layout).cast::<usize>();
-
-        unsafe {
-            for i in 0..max_threads {
-                std::ptr::write(ptr.as_ptr().add(i), 0);
-            }
-
-            VersionVec {
-                versions: std::slice::from_raw_parts_mut(ptr.as_ptr(), max_threads),
-            }
+        VersionVec {
+            versions: bump.alloc_slice_fill_copy(max_threads, 0),
         }
     }
 

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -44,6 +44,18 @@ impl<T: ops::DerefMut<Target = [usize]>> VersionVecGen<T> {
         }
     }
 
+    pub(crate) fn clone_bump<'bump, U>(
+        other: &VersionVecGen<U>,
+        bump: &'bump Bump,
+    ) -> VersionVecSlice<'bump>
+    where
+        U: ops::DerefMut<Target = [usize]>,
+    {
+        VersionVecSlice {
+            versions: bump.alloc_slice_copy(&other.versions),
+        }
+    }
+
     pub(crate) fn set<U>(&mut self, other: &VersionVecGen<U>)
     where
         U: ops::DerefMut<Target = [usize]>,


### PR DESCRIPTION
Main changes:
* To deal with the lifetime requirements `Execution` is now re-created for each iteration (only `Path` is created once in the beginning).
* Every bump-allocated object now has a lifetime which can be annoying :(
* `CausalCell` state is moved to the object `Store`.

Apart from that the changes are mostly mechanical.

The remaining big source of periodic allocations is https://github.com/tokio-rs/loom/blob/3fb6e6efb4403c14ce7963b5b7f6574710153440/src/sync/atomic/atomic.rs#L12 but it doesn't seem worth the effort to move it inside the `object::Store`.

Again using tokio executor loom tests as a benchmark (`LOOM_MAX_PREEMPTIONS=2 RUSTFLAGS="--cfg loom" cargo test --release --lib` in the `tokio/tokio-executor` dir), execution time went down from 15.2s to 10.9s compared to master  🎉