### PR TITLE
fixes Loom when using async/await

### DIFF
--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -55,7 +55,9 @@ impl Scheduler {
         use std::ptr;
         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
-        unsafe fn noop_clone(_: *const ()) -> RawWaker { unreachable!() }
+        unsafe fn noop_clone(_: *const ()) -> RawWaker {
+            unreachable!()
+        }
         unsafe fn noop(_: *const ()) {}
 
         // Wrapping with an async block deals with the thread-local context
@@ -65,16 +67,12 @@ impl Scheduler {
 
         let raw_waker = RawWaker::new(
             ptr::null(),
-            &RawWakerVTable::new(
-                noop_clone,
-                noop,
-                noop,
-                noop));
+            &RawWakerVTable::new(noop_clone, noop, noop, noop),
+        );
         let mut waker = unsafe { Waker::from_raw(raw_waker) };
         let mut cx = Context::from_waker(&mut waker);
 
         assert!(switch.poll(&mut cx).is_ready());
-
     }
 
     pub(crate) fn spawn(f: Box<dyn FnOnce()>) {

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -50,7 +50,31 @@ impl Scheduler {
 
     /// Perform a context switch
     pub(crate) fn switch() {
-        generator::yield_with(());
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::ptr;
+        use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+
+        unsafe fn noop_clone(_: *const ()) -> RawWaker { unreachable!() }
+        unsafe fn noop(_: *const ()) {}
+
+        // Wrapping with an async block deals with the thread-local context
+        // `std` uses to manage async blocks
+        let mut switch = async { generator::yield_with(()) };
+        let switch = unsafe { Pin::new_unchecked(&mut switch) };
+
+        let raw_waker = RawWaker::new(
+            ptr::null(),
+            &RawWakerVTable::new(
+                noop_clone,
+                noop,
+                noop,
+                noop));
+        let mut waker = unsafe { Waker::from_raw(raw_waker) };
+        let mut cx = Context::from_waker(&mut waker);
+
+        assert!(switch.poll(&mut cx).is_ready());
+
     }
 
     pub(crate) fn spawn(f: Box<dyn FnOnce()>) {


### PR DESCRIPTION
Loom uses its own thread implementation using generators. Unfortunately,
this means that thread-locals do not work when using a loom model as all
code runs on a single physical thread. Loom provides a mocked
thread_local API to work around this.

However, when using `async / await`, `std` uses an internal thread-local
to track the waker as it passes through the async block. If loom
preempts at this point, the context gets shared with the wrong thread,
resulting in SEGV.

This patch fixes this by wrapping the loom context switch with an async
block and polling the async block w/ a noop waker. Doing this forces the
real waker to be moved out of thread-local storage and to the stack,
which is persisted across the loom context switch.