### PR TITLE
Add support for RwLock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 target
 Cargo.lock
-
-# Vim
-.*.swp
-.*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 Cargo.lock
+
+# Vim
+.*.swp
+.*.swo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,8 @@
 //! case and control the scheduling.
 //!
 //! Tests must use the loom synchronization types, such as `Atomic*`, `Mutex`,
-//! `Condvar`, `thread::spawn`, etc. When writing a concurrent program, the
-//! `std` types should be used when running the program and the `loom` types
+//! `RwLock`, `Condvar`, `thread::spawn`, etc. When writing a concurrent program,
+//! the `std` types should be used when running the program and the `loom` types
 //! when running the test.
 //!
 //! One way to do this is via cfg flags.

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -27,6 +27,9 @@ pub(crate) use self::mutex::Mutex;
 mod path;
 pub(crate) use self::path::Path;
 
+mod rwlock;
+pub(crate) use self::rwlock::RwLock;
+
 mod scheduler;
 pub(crate) use self::scheduler::Scheduler;
 

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,4 +1,4 @@
-use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify};
+use crate::rt::{alloc, arc, atomic, condvar, execution, mutex, notify, rwlock};
 use crate::rt::{Access, Execution};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -27,9 +27,10 @@ enum Entry {
     Alloc(alloc::State),
     Arc(arc::State),
     Atomic(atomic::State),
-    Mutex(mutex::State),
     Condvar(condvar::State),
+    Mutex(mutex::State),
     Notify(notify::State),
+    RwLock(rwlock::State),
 }
 
 // TODO: mov to separate file
@@ -106,6 +107,15 @@ impl Object {
             _ => None,
         }
     }
+
+    pub(super) fn rwlock_mut(self, store: &mut Store) -> Option<&mut rwlock::State> {
+        assert_eq!(self.execution_id, store.execution_id);
+
+        match &mut store.entries[self.index] {
+            Entry::RwLock(v) => Some(v),
+            _ => None,
+        }
+    }
 }
 
 impl Store {
@@ -155,6 +165,11 @@ impl Store {
         self.insert(Entry::Notify(state))
     }
 
+    /// Insert a new rwlock object into the store.
+    pub(super) fn insert_rwlock(&mut self, state: rwlock::State) -> Object {
+        self.insert(Entry::RwLock(state))
+    }
+
     fn insert(&mut self, entry: Entry) -> Object {
         let index = self.entries.len();
         self.entries.push(entry);
@@ -176,6 +191,7 @@ impl Store {
             Entry::Mutex(entry) => entry.last_dependent_accesses(),
             Entry::Condvar(entry) => entry.last_dependent_accesses(),
             Entry::Notify(entry) => entry.last_dependent_accesses(),
+            Entry::RwLock(entry) => entry.last_dependent_accesses(),
         }
     }
 
@@ -187,6 +203,7 @@ impl Store {
             Entry::Mutex(entry) => entry.set_last_access(access),
             Entry::Condvar(entry) => entry.set_last_access(access),
             Entry::Notify(entry) => entry.set_last_access(access),
+            Entry::RwLock(entry) => entry.set_last_access(access),
         }
     }
 

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -1,0 +1,269 @@
+use crate::rt::{
+    object::{self, Object},
+    thread, Access, Synchronize,
+};
+
+use std::collections::HashSet;
+use std::sync::atomic::Ordering::{Acquire, Release};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) struct RwLock {
+    obj: Object,
+}
+
+#[derive(Debug, PartialEq)]
+enum RwLockType {
+    Read(HashSet<thread::Id>),
+    Write(thread::Id),
+}
+
+#[derive(Debug)]
+pub(super) struct State {
+    /// If the rwlock should establish sequential consistency.
+    seq_cst: bool,
+
+    /// `Some` when the rwlock is in the locked state.
+    /// The `thread::Id` references the thread that currently holds the rwlock.
+    lock: Option<RwLockType>,
+
+    /// Tracks write access to the rwlock.
+    last_access: Option<Access>,
+
+    /// Causality transfers between threads
+    synchronize: Synchronize,
+}
+
+impl RwLock {
+    /// Common RwLock function
+    pub(crate) fn new(seq_cst: bool) -> RwLock {
+        super::execution(|execution| {
+            let obj = execution.objects.insert_rwlock(State {
+                seq_cst,
+                lock: None,
+                last_access: None,
+                synchronize: Synchronize::new(execution.max_threads),
+            });
+
+            RwLock { obj }
+        })
+    }
+
+    fn get_state<'a>(&self, objects: &'a mut object::Store) -> &'a mut State {
+        self.obj.rwlock_mut(objects).unwrap()
+    }
+}
+
+impl RwLock {
+    /// Read RwLock functions
+    pub(crate) fn acquire_read_lock(&self) {
+        self.obj.branch_acquire(self.is_write_locked());
+        assert!(
+            self.post_acquire_read_lock(),
+            "expected to be able to acquire read lock"
+        );
+    }
+
+    pub(crate) fn try_acquire_read_lock(&self) -> bool {
+        self.obj.branch_opaque();
+        self.post_acquire_read_lock()
+    }
+
+    pub(crate) fn release_read_lock(&self) {
+        super::execution(|execution| {
+            let state = self.get_state(&mut execution.objects);
+
+            state.lock = None;
+
+            state
+                .synchronize
+                .sync_store(&mut execution.threads, Release);
+
+            if state.seq_cst {
+                execution.threads.seq_cst();
+            }
+
+            let thread_id = execution.threads.active_id();
+
+            for (id, thread) in execution.threads.iter_mut() {
+                if id == thread_id {
+                    continue;
+                }
+
+                let obj = thread
+                    .operation
+                    .as_ref()
+                    .map(|operation| operation.object());
+
+                if obj == Some(self.obj) {
+                    thread.set_runnable();
+                }
+            }
+        });
+    }
+
+    fn post_acquire_read_lock(&self) -> bool {
+        super::execution(|execution| {
+            let state = self.get_state(&mut execution.objects);
+            let thread_id = execution.threads.active_id();
+
+            let thread_set = match &state.lock {
+                None => {
+                    let mut threads: HashSet<thread::Id> = HashSet::new();
+                    threads.insert(thread_id);
+                    threads
+                }
+                Some(RwLockType::Read(current)) => {
+                    let mut threads: HashSet<thread::Id> = HashSet::new();
+                    threads.extend(current);
+                    threads.insert(thread_id);
+                    threads
+                }
+                Some(RwLockType::Write(_)) => return false,
+            };
+
+            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
+
+            if state.seq_cst {
+                execution.threads.seq_cst();
+            }
+
+            // Block all writer threads from attempting to acquire the RwLock
+            for (id, thread) in execution.threads.iter_mut() {
+                if thread_set.contains(&id) {
+                    continue;
+                }
+
+                let obj = thread
+                    .operation
+                    .as_ref()
+                    .map(|operation| operation.object());
+
+                if obj == Some(self.obj) {
+                    thread.set_blocked();
+                }
+            }
+
+            state.lock = Some(RwLockType::Read(thread_set));
+
+            true
+        })
+    }
+
+    fn is_read_locked(&self) -> bool {
+        super::execution(
+            |execution| match self.get_state(&mut execution.objects).lock {
+                Some(RwLockType::Read(_)) => true,
+                _ => false,
+            },
+        )
+    }
+}
+
+impl RwLock {
+    /// Write RwLock functions
+    pub(crate) fn acquire_write_lock(&self) {
+        self.obj
+            .branch_acquire(self.is_write_locked() || self.is_read_locked());
+        assert!(
+            self.post_acquire_write_lock(),
+            "expected to be able to acquire write lock"
+        );
+    }
+
+    pub(crate) fn try_acquire_write_lock(&self) -> bool {
+        self.obj.branch_opaque();
+        self.post_acquire_write_lock()
+    }
+
+    pub(crate) fn release_write_lock(&self) {
+        super::execution(|execution| {
+            let state = self.get_state(&mut execution.objects);
+
+            state.lock = None;
+
+            state
+                .synchronize
+                .sync_store(&mut execution.threads, Release);
+
+            if state.seq_cst {
+                // Establish sequential consistency between the lock's operations.
+                execution.threads.seq_cst();
+            }
+
+            let thread_id = execution.threads.active_id();
+
+            // Block all other threads from attempting to acquire the RwLock
+            for (id, thread) in execution.threads.iter_mut() {
+                if id == thread_id {
+                    continue;
+                }
+
+                let obj = thread
+                    .operation
+                    .as_ref()
+                    .map(|operation| operation.object());
+
+                if obj == Some(self.obj) {
+                    thread.set_runnable();
+                }
+            }
+        });
+    }
+
+    fn post_acquire_write_lock(&self) -> bool {
+        super::execution(|execution| {
+            let state = self.get_state(&mut execution.objects);
+            let thread_id = execution.threads.active_id();
+
+            // Set the lock to the current thread
+            state.lock = match state.lock {
+                Some(RwLockType::Read(_)) => return false,
+                _ => Some(RwLockType::Write(thread_id)),
+            };
+
+            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
+
+            if state.seq_cst {
+                // Establish sequential consistency between locks
+                execution.threads.seq_cst();
+            }
+
+            // Block all other threads attempting to acquire rwlock
+            for (id, thread) in execution.threads.iter_mut() {
+                if id == thread_id {
+                    continue;
+                }
+
+                let obj = thread
+                    .operation
+                    .as_ref()
+                    .map(|operation| operation.object());
+
+                if obj == Some(self.obj) {
+                    thread.set_blocked();
+                }
+            }
+
+            true
+        })
+    }
+
+    fn is_write_locked(&self) -> bool {
+        super::execution(
+            |execution| match self.get_state(&mut execution.objects).lock {
+                Some(RwLockType::Write(_)) => true,
+                Some(RwLockType::Read(_)) | None => false,
+            },
+        )
+    }
+}
+
+impl State {
+    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
+        Box::new(self.last_access.iter())
+    }
+
+    pub(crate) fn set_last_access(&mut self, access: Access) {
+        self.last_access = Some(access);
+    }
+}

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -1,7 +1,7 @@
 use crate::rt::{
     execution,
     object::{self, Object},
-    thread, Access, Synchronize,
+    thread, Access, Synchronize, VersionVec,
 };
 
 use std::collections::HashSet;
@@ -233,11 +233,11 @@ impl RwLock {
 }
 
 impl State {
-    pub(crate) fn last_dependent_accesses<'a>(&'a self) -> Box<dyn Iterator<Item = &Access> + 'a> {
-        Box::new(self.last_access.iter())
+    pub(crate) fn last_dependent_access(&self) -> Option<&Access> {
+        self.last_access.as_ref()
     }
 
-    pub(crate) fn set_last_access(&mut self, access: Access) {
-        self.last_access = Some(access);
+    pub(crate) fn set_last_access(&mut self, path_id: usize, version: &VersionVec) {
+        Access::set_or_create(&mut self.last_access, path_id, version);
     }
 }

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -1,4 +1,5 @@
 use crate::rt::{
+    execution,
     object::{self, Object},
     thread, Access, Synchronize,
 };
@@ -12,19 +13,16 @@ pub(crate) struct RwLock {
 }
 
 #[derive(Debug, PartialEq)]
-enum RwLockType {
+enum Locked {
     Read(HashSet<thread::Id>),
     Write(thread::Id),
 }
 
 #[derive(Debug)]
 pub(super) struct State {
-    /// If the rwlock should establish sequential consistency.
-    seq_cst: bool,
-
-    /// `Some` when the rwlock is in the locked state.
-    /// The `thread::Id` references the thread that currently holds the rwlock.
-    lock: Option<RwLockType>,
+    /// A single `thread::Id` when Write locked.
+    /// A set of `thread::Id` when Read locked.
+    lock: Option<Locked>,
 
     /// Tracks write access to the rwlock.
     last_access: Option<Access>,
@@ -35,10 +33,9 @@ pub(super) struct State {
 
 impl RwLock {
     /// Common RwLock function
-    pub(crate) fn new(seq_cst: bool) -> RwLock {
+    pub(crate) fn new() -> RwLock {
         super::execution(|execution| {
             let obj = execution.objects.insert_rwlock(State {
-                seq_cst,
                 lock: None,
                 last_access: None,
                 synchronize: Synchronize::new(execution.max_threads),
@@ -48,13 +45,8 @@ impl RwLock {
         })
     }
 
-    fn get_state<'a>(&self, objects: &'a mut object::Store) -> &'a mut State {
-        self.obj.rwlock_mut(objects).unwrap()
-    }
-}
-
-impl RwLock {
-    /// Read RwLock functions
+    /// Acquire the read lock.
+    /// Fail to acquire read lock if already *write* locked.
     pub(crate) fn acquire_read_lock(&self) {
         self.obj.branch_acquire(self.is_write_locked());
         assert!(
@@ -63,9 +55,25 @@ impl RwLock {
         );
     }
 
+    /// Acquire write lock.
+    /// Fail to acquire write lock if either read or write locked.
+    pub(crate) fn acquire_write_lock(&self) {
+        self.obj
+            .branch_acquire(self.is_write_locked() || self.is_read_locked());
+        assert!(
+            self.post_acquire_write_lock(),
+            "expected to be able to acquire write lock"
+        );
+    }
+
     pub(crate) fn try_acquire_read_lock(&self) -> bool {
         self.obj.branch_opaque();
         self.post_acquire_read_lock()
+    }
+
+    pub(crate) fn try_acquire_write_lock(&self) -> bool {
+        self.obj.branch_opaque();
+        self.post_acquire_write_lock()
     }
 
     pub(crate) fn release_read_lock(&self) {
@@ -78,101 +86,13 @@ impl RwLock {
                 .synchronize
                 .sync_store(&mut execution.threads, Release);
 
-            if state.seq_cst {
-                execution.threads.seq_cst();
-            }
+            // Establish sequential consistency between the lock's operations.
+            execution.threads.seq_cst();
 
             let thread_id = execution.threads.active_id();
 
-            for (id, thread) in execution.threads.iter_mut() {
-                if id == thread_id {
-                    continue;
-                }
-
-                let obj = thread
-                    .operation
-                    .as_ref()
-                    .map(|operation| operation.object());
-
-                if obj == Some(self.obj) {
-                    thread.set_runnable();
-                }
-            }
+            self.unlock_threads(execution, thread_id);
         });
-    }
-
-    fn post_acquire_read_lock(&self) -> bool {
-        super::execution(|execution| {
-            let state = self.get_state(&mut execution.objects);
-            let thread_id = execution.threads.active_id();
-
-            let thread_set = match &state.lock {
-                None => {
-                    let mut threads: HashSet<thread::Id> = HashSet::new();
-                    threads.insert(thread_id);
-                    threads
-                }
-                Some(RwLockType::Read(current)) => {
-                    let mut threads: HashSet<thread::Id> = HashSet::new();
-                    threads.extend(current);
-                    threads.insert(thread_id);
-                    threads
-                }
-                Some(RwLockType::Write(_)) => return false,
-            };
-
-            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
-
-            if state.seq_cst {
-                execution.threads.seq_cst();
-            }
-
-            // Block all writer threads from attempting to acquire the RwLock
-            for (id, thread) in execution.threads.iter_mut() {
-                if thread_set.contains(&id) {
-                    continue;
-                }
-
-                let obj = thread
-                    .operation
-                    .as_ref()
-                    .map(|operation| operation.object());
-
-                if obj == Some(self.obj) {
-                    thread.set_blocked();
-                }
-            }
-
-            state.lock = Some(RwLockType::Read(thread_set));
-
-            true
-        })
-    }
-
-    fn is_read_locked(&self) -> bool {
-        super::execution(
-            |execution| match self.get_state(&mut execution.objects).lock {
-                Some(RwLockType::Read(_)) => true,
-                _ => false,
-            },
-        )
-    }
-}
-
-impl RwLock {
-    /// Write RwLock functions
-    pub(crate) fn acquire_write_lock(&self) {
-        self.obj
-            .branch_acquire(self.is_write_locked() || self.is_read_locked());
-        assert!(
-            self.post_acquire_write_lock(),
-            "expected to be able to acquire write lock"
-        );
-    }
-
-    pub(crate) fn try_acquire_write_lock(&self) -> bool {
-        self.obj.branch_opaque();
-        self.post_acquire_write_lock()
     }
 
     pub(crate) fn release_write_lock(&self) {
@@ -185,29 +105,108 @@ impl RwLock {
                 .synchronize
                 .sync_store(&mut execution.threads, Release);
 
-            if state.seq_cst {
-                // Establish sequential consistency between the lock's operations.
-                execution.threads.seq_cst();
-            }
+            // Establish sequential consistency between the lock's operations.
+            execution.threads.seq_cst();
 
             let thread_id = execution.threads.active_id();
 
-            // Block all other threads from attempting to acquire the RwLock
-            for (id, thread) in execution.threads.iter_mut() {
-                if id == thread_id {
-                    continue;
-                }
-
-                let obj = thread
-                    .operation
-                    .as_ref()
-                    .map(|operation| operation.object());
-
-                if obj == Some(self.obj) {
-                    thread.set_runnable();
-                }
-            }
+            self.unlock_threads(execution, thread_id);
         });
+    }
+
+    fn lock_out_threads(&self, execution: &mut execution::Execution, thread_id: thread::Id) {
+        // TODO: This and the following function look very similar.
+        // Refactor the two to DRY the code.
+        for (id, thread) in execution.threads.iter_mut() {
+            if id == thread_id {
+                continue;
+            }
+
+            let obj = thread
+                .operation
+                .as_ref()
+                .map(|operation| operation.object());
+
+            if obj == Some(self.obj) {
+                thread.set_blocked();
+            }
+        }
+    }
+
+    fn unlock_threads(&self, execution: &mut execution::Execution, thread_id: thread::Id) {
+        // TODO: This and the above function look very similar.
+        // Refactor the two to DRY the code.
+        for (id, thread) in execution.threads.iter_mut() {
+            if id == thread_id {
+                continue;
+            }
+
+            let obj = thread
+                .operation
+                .as_ref()
+                .map(|operation| operation.object());
+
+            if obj == Some(self.obj) {
+                thread.set_runnable();
+            }
+        }
+    }
+
+    fn get_state<'a>(&self, objects: &'a mut object::Store) -> &'a mut State {
+        self.obj.rwlock_mut(objects).unwrap()
+    }
+
+    /// Returns `true` if RwLock is read locked
+    fn is_read_locked(&self) -> bool {
+        super::execution(
+            |execution| match self.get_state(&mut execution.objects).lock {
+                Some(Locked::Read(_)) => true,
+                _ => false,
+            },
+        )
+    }
+
+    /// Returns `true` if RwLock is write locked.
+    fn is_write_locked(&self) -> bool {
+        super::execution(
+            |execution| match self.get_state(&mut execution.objects).lock {
+                Some(Locked::Write(_)) => true,
+                _ => false,
+            },
+        )
+    }
+
+    fn post_acquire_read_lock(&self) -> bool {
+        super::execution(|execution| {
+            let mut state = self.get_state(&mut execution.objects);
+            let thread_id = execution.threads.active_id();
+
+            // Set the lock to the current thread
+            state.lock = match &state.lock {
+                None => {
+                    let mut threads: HashSet<thread::Id> = HashSet::new();
+                    threads.insert(thread_id);
+                    Some(Locked::Read(threads))
+                }
+                Some(Locked::Read(current)) => {
+                    // TODO: refactor this to not create a `new` HashSet
+                    let mut new: HashSet<thread::Id> = HashSet::new();
+                    new.extend(current);
+                    new.insert(thread_id);
+                    Some(Locked::Read(new))
+                }
+                Some(Locked::Write(_)) => return false,
+            };
+
+            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
+
+            execution.threads.seq_cst();
+
+            // Block all writer threads from attempting to acquire the RwLock
+            self.lock_out_threads(execution, thread_id);
+
+            true
+        })
     }
 
     fn post_acquire_write_lock(&self) -> bool {
@@ -217,44 +216,19 @@ impl RwLock {
 
             // Set the lock to the current thread
             state.lock = match state.lock {
-                Some(RwLockType::Read(_)) => return false,
-                _ => Some(RwLockType::Write(thread_id)),
+                Some(Locked::Read(_)) => return false,
+                _ => Some(Locked::Write(thread_id)),
             };
 
             dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
 
-            if state.seq_cst {
-                // Establish sequential consistency between locks
-                execution.threads.seq_cst();
-            }
+            // Establish sequential consistency between locks
+            execution.threads.seq_cst();
 
             // Block all other threads attempting to acquire rwlock
-            for (id, thread) in execution.threads.iter_mut() {
-                if id == thread_id {
-                    continue;
-                }
-
-                let obj = thread
-                    .operation
-                    .as_ref()
-                    .map(|operation| operation.object());
-
-                if obj == Some(self.obj) {
-                    thread.set_blocked();
-                }
-            }
 
             true
         })
-    }
-
-    fn is_write_locked(&self) -> bool {
-        super::execution(
-            |execution| match self.get_state(&mut execution.objects).lock {
-                Some(RwLockType::Write(_)) => true,
-                Some(RwLockType::Read(_)) | None => false,
-            },
-        )
     }
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -5,11 +5,13 @@ pub mod atomic;
 mod condvar;
 mod mutex;
 mod notify;
+mod rwlock;
 
 pub use self::arc::Arc;
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{Mutex, MutexGuard};
 pub use self::notify::Notify;
+pub use self::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use std::sync::{LockResult, TryLockResult};
 

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -1,0 +1,140 @@
+use crate::rt;
+
+use std::{
+    ops,
+    sync::{LockResult, TryLockError, TryLockResult},
+};
+
+/// Mock implementatoin of `std::sync::RwLock`
+#[derive(Debug)]
+pub struct RwLock<T> {
+    object: rt::RwLock,
+    data: std::sync::RwLock<T>,
+}
+
+/// Mock implementation of `std::sync::RwLockReadGuard`
+#[derive(Debug)]
+pub struct RwLockReadGuard<'a, T> {
+    lock: &'a RwLock<T>,
+    data: Option<std::sync::RwLockReadGuard<'a, T>>,
+}
+
+/// Mock implementation of `std::sync::rwLockWriteGuard`
+#[derive(Debug)]
+pub struct RwLockWriteGuard<'a, T> {
+    lock: &'a RwLock<T>,
+    data: Option<std::sync::RwLockWriteGuard<'a, T>>,
+}
+
+impl<T> RwLock<T> {
+    /// Creates a new rwlock in an unlocked state ready for use.
+    pub fn new(data: T) -> RwLock<T> {
+        RwLock {
+            data: std::sync::RwLock::new(data),
+            object: rt::RwLock::new(true),
+        }
+    }
+
+    /// Locks this rwlock with shared read access, blocking the current
+    /// thread until it can be acquired.
+    ///
+    /// The calling thread will be blocked until there are no more writers
+    /// which hold the lock. There may be other readers currently inside the
+    /// lock when this method returns. This method does not provide any
+    /// guarantees with respect to the ordering of whether contentious readers
+    /// or writers will acquire the lock first.
+    pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
+        self.object.acquire_read_lock();
+
+        Ok(RwLockReadGuard {
+            lock: self,
+            data: Some(self.data.read().unwrap()),
+        })
+    }
+
+    /// Attempts to acquire this rwlock with shared read access.
+    ///
+    /// If the access could not be granted at this time, then Err is returned.
+    /// Otherwise, an RAII guard is returned which will release the shared
+    /// access when it is dropped.
+    ///
+    /// This function does not block.
+    pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<'_, T>> {
+        if self.object.try_acquire_read_lock() {
+            Ok(RwLockReadGuard {
+                lock: self,
+                data: Some(self.data.read().unwrap()),
+            })
+        } else {
+            Err(TryLockError::WouldBlock)
+        }
+    }
+
+    /// Locks this rwlock with exclusive write access, blocking the current
+    /// thread until it can be acquired.
+    ///
+    /// This function will not return while other writers or other readers
+    /// currently have access to the lock.
+    pub fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
+        self.object.acquire_write_lock();
+
+        Ok(RwLockWriteGuard {
+            lock: self,
+            data: Some(self.data.write().unwrap()),
+        })
+    }
+
+    /// Attempts to lock this rwlock with exclusive write access.
+    ///
+    /// If the lock could not be acquired at this time, then Err is returned.
+    /// Otherwise, an RAII guard is returned which will release the lock when
+    /// it is dropped.
+    ///
+    /// This function does not block.
+    pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<'_, T>> {
+        if self.object.try_acquire_write_lock() {
+            Ok(RwLockWriteGuard {
+                lock: self,
+                data: Some(self.data.write().unwrap()),
+            })
+        } else {
+            Err(TryLockError::WouldBlock)
+        }
+    }
+}
+
+impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.data.as_ref().unwrap().deref()
+    }
+}
+
+impl<'a, T: 'a> Drop for RwLockReadGuard<'a, T> {
+    fn drop(&mut self) {
+        self.data = None;
+        self.lock.object.release_read_lock()
+    }
+}
+
+impl<'a, T> ops::Deref for RwLockWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.data.as_ref().unwrap().deref()
+    }
+}
+
+impl<'a, T> ops::DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.data.as_mut().unwrap().deref_mut()
+    }
+}
+
+impl<'a, T: 'a> Drop for RwLockWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        self.data = None;
+        self.lock.object.release_write_lock()
+    }
+}

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -23,6 +23,8 @@ pub struct RwLockReadGuard<'a, T> {
 #[derive(Debug)]
 pub struct RwLockWriteGuard<'a, T> {
     lock: &'a RwLock<T>,
+    /// `data` is an Option so that the Drop impl can drop the std guard and release the std lock
+    /// before releasing the loom mock lock, as that might cause another thread to acquire the lock
     data: Option<std::sync::RwLockWriteGuard<'a, T>>,
 }
 
@@ -31,7 +33,7 @@ impl<T> RwLock<T> {
     pub fn new(data: T) -> RwLock<T> {
         RwLock {
             data: std::sync::RwLock::new(data),
-            object: rt::RwLock::new(true),
+            object: rt::RwLock::new(),
         }
     }
 

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
 
 use loom;
 

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -1,0 +1,60 @@
+use loom;
+
+use loom::{
+    sync::{Arc, RwLock},
+    thread,
+};
+
+#[test]
+fn rwlock_read() {
+    loom::model(|| {
+        let lock = Arc::new(RwLock::new(1));
+        let c_lock = lock.clone();
+
+        let n = lock.read().unwrap();
+        assert_eq!(*n, 1);
+
+        thread::spawn(move || {
+            let r = c_lock.read();
+            assert!(r.is_ok());
+        })
+        .join()
+        .unwrap();
+    });
+}
+
+#[test]
+fn rwlock_try_read() {
+    loom::model(|| {
+        let lock = RwLock::new(1);
+
+        match lock.try_read() {
+            Ok(n) => assert_eq!(*n, 1),
+            Err(_) => unreachable!(),
+        };
+    });
+}
+
+#[test]
+fn rwlock_write() {
+    loom::model(|| {
+        let lock = RwLock::new(1);
+
+        let mut n = lock.write().unwrap();
+        *n = 2;
+
+        assert!(lock.try_read().is_err());
+    });
+}
+
+#[test]
+fn rwlock_try_write() {
+    loom::model(|| {
+        let lock = RwLock::new(1);
+
+        let n = lock.read().unwrap();
+        assert_eq!(*n, 1);
+
+        assert!(lock.try_write().is_err());
+    });
+}


### PR DESCRIPTION
Fixes #21

This branch adds support for mock `RwLock`s. This PR is the same as PR
#88, but updated to build against the current master. All credit is due
to @pop.