### PR TITLE
Relax how SeqCst is modelled

### DIFF
--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -267,11 +267,9 @@ impl Set {
 
     /// Insert a point of sequential consistency
     pub(crate) fn seq_cst(&mut self) {
-        self.threads[self.active.unwrap()]
-            .causality
-            .join(&self.seq_cst_causality);
-        self.seq_cst_causality
-            .join(&self.threads[self.active.unwrap()].causality);
+        // The previous implementation of sequential consistency was incorrect.
+        // As a quick fix, just disable it. This may fail to model correct code,
+        // but will not silently allow bugs.
     }
 
     pub(crate) fn clear(&mut self, execution_id: execution::Id) {

--- a/tests/causal_cell.rs
+++ b/tests/causal_cell.rs
@@ -353,13 +353,13 @@ fn defer_success() {
         let s2 = s1.clone();
 
         let th = thread::spawn(move || {
-            s2.1.store(1, SeqCst);
+            s2.1.swap(1, SeqCst);
             s2.0.with_mut(|ptr| unsafe { *(*ptr).as_mut_ptr() = 1 });
         });
 
         let (mem, check) = s1.0.with_deferred(|ptr| unsafe { *ptr });
 
-        if 0 == s1.1.load(SeqCst) {
+        if 0 == s1.1.compare_and_swap(0, 0, SeqCst) {
             assert_eq!(unsafe { *mem.as_ptr() }, 0);
             check.check();
         }
@@ -409,7 +409,7 @@ fn batch_defer_success() {
         let s2 = s1.clone();
 
         let th = thread::spawn(move || {
-            s2[0].1.store(1, SeqCst);
+            s2[0].1.swap(1, SeqCst);
             s2[0].0.with_mut(|ptr| unsafe { *(*ptr).as_mut_ptr() = 1 });
         });
 
@@ -421,7 +421,7 @@ fn batch_defer_success() {
         let (mem1, c) = s1[0].0.with_deferred(|ptr| unsafe { *ptr });
         check.join(c);
 
-        if 0 != s1[0].1.load(SeqCst) {
+        if 0 != s1[0].1.compare_and_swap(0, 0, SeqCst) {
             return;
         }
 


### PR DESCRIPTION
The previous SeqCst is incorrectly implemented. SeqCst is identical to
AcqRel except that it provides a sequental modification order. The
previous imlementation provided global happens-before, which is too
strong.

As a stop-gap, this PR disables SeqCst support, which means it will fail
to validate algorithms that correctly rely on SeqCst guarantees.
However, it should prevent validationg buggy code.