### PR TITLE
basic backtrace tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ serde = { version = "1.0.92", features = ["derive"], optional = true }
 serde_json = { version = "1.0.33", optional = true }
 
 futures-util = { version = "0.3.0", optional = true }
+backtrace = { version = "0.3.44", optional = true }

--- a/src/model.rs
+++ b/src/model.rs
@@ -45,6 +45,15 @@ pub struct Builder {
     /// Defaults to `LOOM_CHECKPOINT_INTERVAL` environment variable.
     pub checkpoint_interval: usize,
 
+    /// When `true`, backtraces are captured on each loom operation.
+    ///
+    /// Note that is is **very** expensive. It is recommended to first isolate a
+    /// failing iteration using `LOOM_CHECKPOINT_FILE`, then enable backtrace
+    /// collection.
+    ///
+    /// Defaults to `LOOM_BACKTRACE` environment variable.
+    pub backtrace: bool,
+
     /// Log execution output to stdout.
     ///
     /// Defaults to existance of `LOOM_LOG` environment variable.
@@ -74,6 +83,8 @@ impl Builder {
                     .expect("invalid value for `LOOM_MAX_BRANCHES`")
             })
             .unwrap_or(DEFAULT_MAX_BRANCHES);
+
+        let backtrace = env::var("LOOM_BACKTRACE").is_ok();
 
         let log = env::var("LOOM_LOG").is_ok();
 
@@ -119,6 +130,7 @@ impl Builder {
             preemption_bound,
             checkpoint_file,
             checkpoint_interval,
+            backtrace,
             log,
             _p: (),
         }
@@ -146,6 +158,7 @@ impl Builder {
         }
 
         execution.log = self.log;
+        execution.backtrace = self.backtrace;
 
         let f = Arc::new(f);
 

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -1,5 +1,5 @@
-use crate::rt::{self, Access, Backtrace, Synchronize, VersionVec};
 use crate::rt::object::Object;
+use crate::rt::{self, Access, Backtrace, Synchronize, VersionVec};
 
 use std::sync::atomic::Ordering::{Acquire, Release};
 
@@ -123,7 +123,10 @@ impl State {
     pub(super) fn check_for_leaks(&self) {
         if self.ref_cnt != 0 {
             if let Some(backtrace) = &self.allocated {
-                panic!("Arc leaked.\n------------\nAllocated:\n\n{}\n------------\n", backtrace);
+                panic!(
+                    "Arc leaked.\n------------\nAllocated:\n\n{}\n------------\n",
+                    backtrace
+                );
             } else {
                 panic!("Arc leaked.");
             }

--- a/src/rt/backtrace.rs
+++ b/src/rt/backtrace.rs
@@ -35,7 +35,7 @@ mod cfg {
     }
 
     impl fmt::Display for Backtrace {
-        fn fmt(&self, fmt: &fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(fmt, "[enable `backtrace` feature for backtrace capture]")
         }
     }

--- a/src/rt/backtrace.rs
+++ b/src/rt/backtrace.rs
@@ -1,0 +1,42 @@
+pub(crate) use cfg::Backtrace;
+
+#[cfg(feature = "backtrace")]
+mod cfg {
+    use std::fmt;
+
+    #[derive(Debug)]
+    pub(crate) struct Backtrace(backtrace::Backtrace);
+
+    impl Backtrace {
+        pub(crate) fn capture() -> Backtrace {
+            Backtrace(backtrace::Backtrace::new())
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // TODO: Add some sort of filter to get rid of loom internals
+            write!(fmt, "{:?}", self.0)
+        }
+    }
+}
+
+#[cfg(not(feature = "backtrace"))]
+mod cfg {
+    use std::fmt;
+
+    #[derive(Debug)]
+    pub(crate) struct Backtrace;
+
+    impl Backtrace {
+        pub(crate) fn capture() -> Backtrace {
+            panic!("enable `backtrace` feature flag");
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, fmt: &fmt::Formatter<'_>) -> fmt::Result {
+            write!(fmt, "[enable `backtrace` feature for backtrace capture]")
+        }
+    }
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -10,6 +10,9 @@ pub(crate) use self::arc::Arc;
 mod atomic;
 pub(crate) use self::atomic::{fence, Atomic};
 
+mod backtrace;
+pub(crate) use self::backtrace::Backtrace;
+
 mod condvar;
 pub(crate) use self::condvar::Condvar;
 


### PR DESCRIPTION
An initial pass at tracking backtraces during execution. Currently, only
`Arc::new` is tracked, but now that infrastructure is added, tracking
additional events should be easier.

Capturing a backtrace is a an expensive event. The failure case should
be isolated before capturing backtraces.