### PR TITLE
Adds guarded ref and mut access for UnsafeCell

### DIFF
--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -2,4 +2,4 @@
 
 mod unsafe_cell;
 
-pub use self::unsafe_cell::UnsafeCell;
+pub use self::unsafe_cell::{UnsafeCell, UnsafeCellMutToken, UnsafeCellRefToken};

--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -12,6 +12,24 @@ pub struct UnsafeCell<T: ?Sized> {
     data: std::cell::UnsafeCell<T>,
 }
 
+/// Token for tracking immutable access to the wrapped value.
+///
+/// This token must be held for as long as the access lasts.
+#[derive(Debug)]
+pub struct UnsafeCellRefToken<T: ?Sized> {
+    data: *const T,
+    token: rt::CellRefToken,
+}
+
+/// Token for tracking mutable access to the wrapped value.
+///
+/// This token must be held for as long as the access lasts.
+#[derive(Debug)]
+pub struct UnsafeCellMutToken<T: ?Sized> {
+    data: *mut T,
+    token: rt::CellMutToken,
+}
+
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified value.
     #[cfg_attr(loom_nightly, track_caller)]
@@ -54,6 +72,36 @@ impl<T: ?Sized> UnsafeCell<T> {
     {
         self.state.with_mut(location!(), || f(self.data.get()))
     }
+
+    /// Get an `UnsafeCellRefToken` that provides scoped immutable access to the
+    /// wrapped value.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the access is not valid under the Rust memory
+    /// model.
+    pub unsafe fn guard_ref_access(&self) -> UnsafeCellRefToken<T> {
+        let token = self.state.guard_ref_access(location!());
+        UnsafeCellRefToken {
+            data: self.data.get() as *const T,
+            token,
+        }
+    }
+
+    /// Get an `UnsafeCellMutToken` that provides scoped mutable access to the
+    /// wrapped value.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the access is not valid under the Rust memory
+    /// model.
+    pub unsafe fn guard_mut_access(&self) -> UnsafeCellMutToken<T> {
+        let token = self.state.guard_mut_access(location!());
+        UnsafeCellMutToken {
+            data: self.data.get(),
+            token,
+        }
+    }
 }
 
 impl<T: Default> Default for UnsafeCell<T> {
@@ -65,5 +113,19 @@ impl<T: Default> Default for UnsafeCell<T> {
 impl<T> From<T> for UnsafeCell<T> {
     fn from(src: T) -> UnsafeCell<T> {
         UnsafeCell::new(src)
+    }
+}
+
+impl<T: ?Sized> UnsafeCellRefToken<T> {
+    /// Get an immutable pointer to the wrapped value.
+    pub const fn get(&self) -> *const T {
+        self.data
+    }
+}
+
+impl<T: ?Sized> UnsafeCellMutToken<T> {
+    /// Get a mutable pointer to the wrapped value.
+    pub const fn get(&self) -> *mut T {
+        self.data
     }
 }

--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -6,7 +6,7 @@ use crate::rt;
 /// `with` and `with_mut`. Both functions take a closure in order to track the
 /// start and end of the access to the underlying cell.
 #[derive(Debug)]
-pub struct UnsafeCell<T> {
+pub struct UnsafeCell<T: ?Sized> {
     /// Causality associated with the cell
     state: rt::Cell,
     data: std::cell::UnsafeCell<T>,
@@ -23,7 +23,9 @@ impl<T> UnsafeCell<T> {
             data: std::cell::UnsafeCell::new(data),
         }
     }
+}
 
+impl<T: ?Sized> UnsafeCell<T> {
     /// Get an immutable pointer to the wrapped value.
     ///
     /// # Panics

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -15,7 +15,7 @@ mod location;
 pub(crate) use self::location::Location;
 
 mod cell;
-pub(crate) use self::cell::Cell;
+pub(crate) use self::cell::{Cell, CellMutToken, CellRefToken};
 
 mod condvar;
 pub(crate) use self::condvar::Condvar;


### PR DESCRIPTION
This PR adds methods `guard_ref_access` and `guard_mut_access` to `UnsafeCell` as an alternative to `with` and `with_mut` for tracking read and write access to the underlying cell data.

The 2 methods return tokens (`UnsafeCellRefToken` and `UnsafeCellMutToken`, respectively) that implement `Drop` so that the beginning of the access can be marked by the invocation of the `guard_*_access` methods and the end of the access is marked by the release of the token object.

I appologize in advance for the lack of proper documentation and tests to accompany the feature. However, I did add doc comments.

This PR also allows the `T` parameter of `UnsafeCell<T>` to be unsized (`T: ?Sized`) to mirror `std::cell::UnsafeCell`, although I can break that out into a separate PR if needed.