### PR TITLE
Add support for mpsc channels

### DIFF
--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -30,7 +30,7 @@ pub(super) struct State {
 ///
 /// Clones are only dependent with inspections. Drops are dependent between each
 /// other.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub(super) enum Action {
     /// Clone the arc
     RefInc,

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -98,7 +98,7 @@ pub(super) struct State {
     cnt: u16,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub(super) enum Action {
     /// Atomic load
     Load,

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -32,6 +32,9 @@ pub(crate) use self::num::Numeric;
 #[macro_use]
 pub(crate) mod object;
 
+mod mpsc;
+pub(crate) use self::mpsc::Channel;
+
 mod mutex;
 pub(crate) use self::mutex::Mutex;
 

--- a/src/rt/mpsc.rs
+++ b/src/rt/mpsc.rs
@@ -126,7 +126,7 @@ impl Channel {
     }
 
     /// Returns `true` if the channel is currently empty
-    fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         super::execution(|execution| self.get_state(&mut execution.objects).msg_cnt == 0)
     }
 

--- a/src/rt/mpsc.rs
+++ b/src/rt/mpsc.rs
@@ -1,4 +1,5 @@
 use crate::rt::{object, Access, Synchronize, VersionVec};
+use std::collections::VecDeque;
 use std::sync::atomic::Ordering::{Acquire, Release};
 
 #[derive(Debug)]
@@ -16,8 +17,25 @@ pub(super) struct State {
     /// Last access that was a receive operation.
     last_recv_access: Option<Access>,
 
-    /// Causality transfers between threads
-    synchronize: Synchronize,
+    /// A synchronization point for synchronizing the sending threads and the
+    /// channel.
+    ///
+    /// The `mpsc` channels have a guarantee that the messages will be received
+    /// in the same order in which they were sent. Therefore, if thread `t1`
+    /// managed to send `m1` before `t2` sent `m2`, the thread that received
+    /// `m2` can be sure that `m1` was already sent and received. In other
+    /// words, it is sound for the receiver of `m2` to know that `m1` happened
+    /// before `m2`. That is why we have a single `sender_synchronize` for
+    /// senders which we use to "timestamp" each message put in the channel.
+    /// However, in our example, the receiver of `m1` does not know whether `m2`
+    /// was already sent or not and, therefore, by reading from the channel it
+    /// should not learn any facts about `happens_before(send(m2), recv(m1))`.
+    /// That is why we cannot use single `Synchronize` for the entire channel
+    /// and on the receiver side we need to use `Synchronize` per message.
+    sender_synchronize: Synchronize,
+    /// A synchronization point per message synchronizing the receiving thread
+    /// with the channel state at the point when the received message was sent.
+    receiver_synchronize: VecDeque<Synchronize>,
 }
 
 /// Actions performed on the Channel.
@@ -36,7 +54,8 @@ impl Channel {
                 msg_cnt: 0,
                 last_send_access: None,
                 last_recv_access: None,
-                synchronize: Synchronize::new(),
+                sender_synchronize: Synchronize::new(),
+                receiver_synchronize: VecDeque::new(),
             });
             Self { state }
         })
@@ -49,8 +68,11 @@ impl Channel {
             state.msg_cnt = state.msg_cnt.checked_add(1).expect("overflow");
 
             state
-                .synchronize
+                .sender_synchronize
                 .sync_store(&mut execution.threads, Release);
+            state
+                .receiver_synchronize
+                .push_back(state.sender_synchronize.clone());
 
             if state.msg_cnt == 1 {
                 // Unblock all threads that are blocked waiting on this channel
@@ -82,7 +104,8 @@ impl Channel {
                 .msg_cnt
                 .checked_sub(1)
                 .expect("expected to be able to read the message");
-            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
+            let mut synchronize = state.receiver_synchronize.pop_front().unwrap();
+            dbg!(synchronize.sync_load(&mut execution.threads, Acquire));
             if state.msg_cnt == 0 {
                 // Block all **other** threads attempting to read from the channel
                 for (id, thread) in execution.threads.iter_mut() {

--- a/src/rt/mpsc.rs
+++ b/src/rt/mpsc.rs
@@ -1,0 +1,133 @@
+use crate::rt::{object, Access, Synchronize, VersionVec};
+use std::sync::atomic::Ordering::{Acquire, Release};
+
+#[derive(Debug)]
+pub(crate) struct Channel {
+    state: object::Ref<State>,
+}
+
+#[derive(Debug)]
+pub(super) struct State {
+    /// Count of messages in the channel.
+    msg_cnt: usize,
+
+    /// Last access that was a send operation.
+    last_send_access: Option<Access>,
+    /// Last access that was a receive operation.
+    last_recv_access: Option<Access>,
+
+    /// Causality transfers between threads
+    synchronize: Synchronize,
+}
+
+/// Actions performed on the Channel.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum Action {
+    /// Send a message
+    MsgSend,
+    /// Receive a message
+    MsgRecv,
+}
+
+impl Channel {
+    pub(crate) fn new() -> Self {
+        super::execution(|execution| {
+            let state = execution.objects.insert(State {
+                msg_cnt: 0,
+                last_send_access: None,
+                last_recv_access: None,
+                synchronize: Synchronize::new(),
+            });
+            Self { state }
+        })
+    }
+
+    pub(crate) fn send(&self) {
+        self.state.branch_action(Action::MsgSend);
+        super::execution(|execution| {
+            let state = self.state.get_mut(&mut execution.objects);
+            state.msg_cnt = state.msg_cnt.checked_add(1).expect("overflow");
+
+            state
+                .synchronize
+                .sync_store(&mut execution.threads, Release);
+
+            if state.msg_cnt == 1 {
+                // Unblock all threads that are blocked waiting on this channel
+                let thread_id = execution.threads.active_id();
+                for (id, thread) in execution.threads.iter_mut() {
+                    if id == thread_id {
+                        continue;
+                    }
+
+                    let obj = thread
+                        .operation
+                        .as_ref()
+                        .map(|operation| operation.object());
+
+                    if obj == Some(self.state.erase()) {
+                        thread.set_runnable();
+                    }
+                }
+            }
+        })
+    }
+
+    pub(crate) fn recv(&self) {
+        self.state.branch_disable(Action::MsgRecv, self.is_empty());
+        super::execution(|execution| {
+            let state = self.state.get_mut(&mut execution.objects);
+            let thread_id = execution.threads.active_id();
+            state.msg_cnt = state
+                .msg_cnt
+                .checked_sub(1)
+                .expect("expected to be able to read the message");
+            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
+            if state.msg_cnt == 0 {
+                // Block all **other** threads attempting to read from the channel
+                for (id, thread) in execution.threads.iter_mut() {
+                    if id == thread_id {
+                        continue;
+                    }
+
+                    if let Some(operation) = thread.operation.as_ref() {
+                        if operation.object() == self.state.erase()
+                            && operation.action() == object::Action::Channel(Action::MsgRecv)
+                        {
+                            thread.set_blocked();
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Returns `true` if the channel is currently empty
+    fn is_empty(&self) -> bool {
+        super::execution(|execution| self.get_state(&mut execution.objects).msg_cnt == 0)
+    }
+
+    fn get_state<'a>(&self, objects: &'a mut object::Store) -> &'a mut State {
+        self.state.get_mut(objects)
+    }
+}
+
+impl State {
+    pub(super) fn check_for_leaks(&self) {
+        assert_eq!(0, self.msg_cnt, "Messages leaked");
+    }
+
+    pub(super) fn last_dependent_access(&self, action: Action) -> Option<&Access> {
+        match action {
+            Action::MsgSend => self.last_send_access.as_ref(),
+            Action::MsgRecv => self.last_recv_access.as_ref(),
+        }
+    }
+
+    pub(super) fn set_last_access(&mut self, action: Action, path_id: usize, version: &VersionVec) {
+        match action {
+            Action::MsgSend => Access::set_or_create(&mut self.last_send_access, path_id, version),
+            Action::MsgRecv => Access::set_or_create(&mut self.last_recv_access, path_id, version),
+        }
+    }
+}

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -65,6 +65,11 @@ impl<T> Arc<T> {
         let inner = std::sync::Arc::from_raw(ptr as *const Inner<T>);
         Arc { inner }
     }
+
+    /// Returns the inner value, if the `Arc` has exactly one strong reference.
+    pub fn try_unwrap(_this: Arc<T>) -> Result<T, Arc<T>> {
+        unimplemented!();
+    }
 }
 
 impl<T> ops::Deref for Arc<T> {

--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -1,0 +1,19 @@
+//! A stub for `std::sync::Barrier`.
+
+#[derive(Debug)]
+/// `std::sync::Barrier` is not supported yet in Loom. This stub is provided just
+/// to make the code to compile.
+pub struct Barrier {}
+
+impl Barrier {
+    /// `std::sync::Barrier` is not supported yet in Loom. This stub is provided just
+    /// to make the code to compile.
+    pub fn new(_n: usize) -> Self {
+        unimplemented!("std::sync::Barrier is not supported yet in Loom.")
+    }
+    /// `std::sync::Barrier` is not supported yet in Loom. This stub is provided just
+    /// to make the code to compile.
+    pub fn wait(&self) -> std::sync::BarrierWaitResult {
+        unimplemented!("std::sync::Barrier is not supported yet in Loom.")
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,6 +3,7 @@
 mod arc;
 pub mod atomic;
 mod condvar;
+pub mod mpsc;
 mod mutex;
 mod notify;
 mod rwlock;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -2,6 +2,7 @@
 
 mod arc;
 pub mod atomic;
+mod barrier;
 mod condvar;
 pub mod mpsc;
 mod mutex;
@@ -9,6 +10,7 @@ mod notify;
 mod rwlock;
 
 pub use self::arc::Arc;
+pub use self::barrier::Barrier;
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{Mutex, MutexGuard};
 pub use self::notify::Notify;

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -1,0 +1,67 @@
+//! A stub for `std::sync::mpsc`.
+
+use crate::rt;
+
+/// Mock implementation of `std::sync::mpsc::channel`.
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (sender_channel, receiver_channel) = std::sync::mpsc::channel();
+    let channel = std::sync::Arc::new(rt::Channel::new());
+    let sender = Sender {
+        object: std::sync::Arc::clone(&channel),
+        sender: sender_channel,
+    };
+    let receiver = Receiver {
+        object: std::sync::Arc::clone(&channel),
+        receiver: receiver_channel,
+    };
+    (sender, receiver)
+}
+
+#[derive(Debug)]
+/// Mock implementation of `std::sync::mpsc::Sender`.
+pub struct Sender<T> {
+    object: std::sync::Arc<rt::Channel>,
+    sender: std::sync::mpsc::Sender<T>,
+}
+
+impl<T> Sender<T> {
+    /// Attempts to send a value on this channel, returning it back if it could
+    /// not be sent.
+    pub fn send(&self, msg: T) -> Result<(), std::sync::mpsc::SendError<T>> {
+        self.object.send();
+        self.sender.send(msg)
+    }
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Sender<T> {
+        Sender {
+            object: std::sync::Arc::clone(&self.object),
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Mock implementation of `std::sync::mpsc::Receiver`.
+pub struct Receiver<T> {
+    object: std::sync::Arc<rt::Channel>,
+    receiver: std::sync::mpsc::Receiver<T>,
+}
+
+impl<T> Receiver<T> {
+    /// Attempts to wait for a value on this receiver, returning an error if the
+    /// corresponding channel has hung up.
+    pub fn recv(&self) -> Result<T, std::sync::mpsc::RecvError> {
+        self.object.recv();
+        self.receiver.recv()
+    }
+    /// Attempts to wait for a value on this receiver, returning an error if the
+    /// corresponding channel has hung up, or if it waits more than `timeout`.
+    pub fn recv_timeout(
+        &self,
+        _timeout: std::time::Duration,
+    ) -> Result<T, std::sync::mpsc::RecvTimeoutError> {
+        unimplemented!("std::sync::mpsc::Receiver::recv_timeout is not supported yet in Loom.")
+    }
+}

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -65,3 +65,12 @@ impl<T> Receiver<T> {
         unimplemented!("std::sync::mpsc::Receiver::recv_timeout is not supported yet in Loom.")
     }
 }
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        // Drain the channel.
+        while !self.object.is_empty() {
+            self.recv().unwrap();
+        }
+    }
+}

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -103,6 +103,11 @@ impl<T> RwLock<T> {
             Err(TryLockError::WouldBlock)
         }
     }
+
+    /// Consumes this `RwLock`, returning the underlying data.
+    pub fn into_inner(self) -> LockResult<T> {
+        unimplemented!()
+    }
 }
 
 impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -77,3 +77,13 @@ fn non_commutative_senders2() {
         ignore_result(r.recv());
     });
 }
+
+#[test]
+fn drop_receiver() {
+    loom::model(|| {
+        let (s, r) = channel();
+        s.send(1).unwrap();
+        s.send(2).unwrap();
+        assert_eq!(r.recv().unwrap(), 1);
+    });
+}

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -1,0 +1,79 @@
+use loom::sync::mpsc::channel;
+use loom::thread;
+
+#[test]
+fn basic_sequential_usage() {
+    loom::model(|| {
+        let (s, r) = channel();
+        s.send(5).unwrap();
+        let val = r.recv().unwrap();
+        assert_eq!(val, 5);
+    });
+}
+
+#[test]
+fn basic_parallel_usage() {
+    loom::model(|| {
+        let (s, r) = channel();
+        thread::spawn(move || {
+            s.send(5).unwrap();
+        });
+        let val = r.recv().unwrap();
+        assert_eq!(val, 5);
+    });
+}
+
+#[test]
+fn commutative_senders() {
+    loom::model(|| {
+        let (s, r) = channel();
+        let s2 = s.clone();
+        thread::spawn(move || {
+            s.send(5).unwrap();
+        });
+        thread::spawn(move || {
+            s2.send(6).unwrap();
+        });
+        let mut val = r.recv().unwrap();
+        val += r.recv().unwrap();
+        assert_eq!(val, 11);
+    });
+}
+
+fn ignore_result<A, B>(_: Result<A, B>) {}
+
+#[test]
+#[should_panic]
+fn non_commutative_senders1() {
+    loom::model(|| {
+        let (s, r) = channel();
+        let s2 = s.clone();
+        thread::spawn(move || {
+            ignore_result(s.send(5));
+        });
+        thread::spawn(move || {
+            ignore_result(s2.send(6));
+        });
+        let val = r.recv().unwrap();
+        assert_eq!(val, 5);
+        ignore_result(r.recv());
+    });
+}
+
+#[test]
+#[should_panic]
+fn non_commutative_senders2() {
+    loom::model(|| {
+        let (s, r) = channel();
+        let s2 = s.clone();
+        thread::spawn(move || {
+            ignore_result(s.send(5));
+        });
+        thread::spawn(move || {
+            ignore_result(s2.send(6));
+        });
+        let val = r.recv().unwrap();
+        assert_eq!(val, 6);
+        ignore_result(r.recv());
+    });
+}


### PR DESCRIPTION
Adds Loom mocks for `std::sync::mpsc`. Also, adds unimplemented stubs for `std::sync::barrier` that the code that depends on them could be at least compiled.

**Note:** This PR includes the changes from #88, so you probably want to merge it first. **cc**: @pop