### PR TITLE
fix `UnsafeCell` bug

### DIFF
--- a/src/rt/cell.rs
+++ b/src/rt/cell.rs
@@ -65,7 +65,7 @@ impl Cell {
         }
 
         // Enter the read closure
-        let _reset = rt::execution(|execution| {
+        let _reset = rt::synchronize(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
 
             assert!(!state.is_writing, "currently writing to cell");
@@ -101,7 +101,7 @@ impl Cell {
         }
 
         // Enter the read closure
-        let _reset = rt::execution(|execution| {
+        let _reset = rt::synchronize(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
 
             assert!(state.is_reading == 0, "currently reading from cell");


### PR DESCRIPTION
The thread version vector was not bumped on `UnsafeCell` access. This
caused synchronizations that happened immediately **before** the access
to prevent loom from detecting invalid `UnsafeCell` access.