### PR TITLE
Don't crash on lazy_static init race

### DIFF
--- a/src/rt/lazy_static.rs
+++ b/src/rt/lazy_static.rs
@@ -50,13 +50,18 @@ impl Set {
         &mut self,
         key: &'static crate::lazy_static::Lazy<T>,
         value: StaticValue,
-    ) {
-        assert!(self
+    ) -> &mut StaticValue {
+        let v = self
             .statics
             .as_mut()
             .expect("attempted to access lazy_static during shutdown")
-            .insert(StaticKeyId::new(key), value)
-            .is_none())
+            .entry(StaticKeyId::new(key));
+
+        if let std::collections::hash_map::Entry::Occupied(_) = v {
+            unreachable!("told to init static, but it was already init'd");
+        }
+
+        v.or_insert(value)
     }
 }
 

--- a/tests/atomic.rs
+++ b/tests/atomic.rs
@@ -17,6 +17,19 @@ loom::thread_local! {
 }
 
 #[test]
+#[should_panic]
+fn lazy_static_arc_shutdown() {
+    loom::model(|| {
+        // note that we are not waiting for this thread,
+        // so it may access the static during shutdown,
+        // which is not okay.
+        thread::spawn(|| {
+            assert_eq!(**NO_LEAK, 0);
+        });
+    });
+}
+
+#[test]
 fn lazy_static_arc_race() {
     loom::model(|| {
         let jh = thread::spawn(|| {


### PR DESCRIPTION
The real lazy_static uses a lock to avoid races in initialization. We
don't implement that lock yet, so our initialization can race. If we do,
we should not crash like we did before.

Fixes #126.