### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn buggy_concurrent_inc() {
                 thread::spawn(move || {
                     let curr = num.load(Acquire);
                     num.store(curr + 1, Release);
-                });
+                })
             })
             .collect();
 


### PR DESCRIPTION
The example in the readme did not compile:
```
th.join().unwrap();
   ^^^^ method not found in `()`
```
The first commit fixes this by removing a semicolon so the thread join handle becomes the value of the iterator.

Secondly. I was pulling my hair for quite a while trying to understand why the test would not fail. It had a bug, why did `loom` not find it? Because the test was marked as `#[should_panic]` of course. Is it not more pedagogical to have a buggy test fail, to show what loom does when it finds an error? 🤔 