### PR TITLE
Implement Default for Mutex, RwLock and Condvar

### DIFF
--- a/src/sync/condvar.rs
+++ b/src/sync/condvar.rs
@@ -68,3 +68,9 @@ impl WaitTimeoutResult {
         self.0
     }
 }
+
+impl Default for Condvar {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -57,6 +57,12 @@ impl<T> Mutex<T> {
     }
 }
 
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<'a, T: 'a> MutexGuard<'a, T> {
     pub(super) fn unborrow(&mut self) {
         self.data = None;

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -108,6 +108,12 @@ impl<T> RwLock<T> {
     }
 }
 
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
     type Target = T;
 


### PR DESCRIPTION
I noticed the `loom` versions of `Mutex` and `RwLock` does not implement `Default`. This PR adds that, so they become more similar.