### PR TITLE
Add configuration option for max stack size

### DIFF
--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -30,8 +30,8 @@ struct State<'a> {
 
 impl Scheduler {
     /// Create an execution
-    pub(crate) fn new(capacity: usize) -> Scheduler {
-        let threads = spawn_threads(capacity);
+    pub(crate) fn new(capacity: usize, stack_size: usize) -> Scheduler {
+        let threads = spawn_threads(capacity, stack_size);
 
         Scheduler {
             threads,
@@ -130,10 +130,10 @@ impl fmt::Debug for Scheduler {
     }
 }
 
-fn spawn_threads(n: usize) -> Vec<Thread> {
+fn spawn_threads(n: usize, stack_size: usize) -> Vec<Thread> {
     (0..n)
         .map(|_| {
-            let mut g = Gn::new(move || {
+            let mut g = Gn::new_opt(stack_size, move || {
                 loop {
                     let f: Option<Box<dyn FnOnce()>> = generator::yield_(()).unwrap();
                     generator::yield_with(());


### PR DESCRIPTION
I have some Loom tests that have started segfaulting because they're overflowing the stack created by generator (the tests are running real code, so I don't have a lot of control over how it uses the stack). generator has an option to pass in a stack size, but Loom doesn't currently expose it. This PR exposes that option in the Builder and the `LOOM_MAX_STACK_SIZE` environment variable, defaulting to 0x1000, which is generator's current default. One oddity of the API is that the stack size is specified in number of machine words rather than bytes, so 0x1000 actually specifies a 32KiB stack.