### PR TITLE
prepare to release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.5 (July 23, 2020)
+# 0.3.5 (July 26, 2020)
 
 ### Fixed
 - An example in the README failing to compile (#132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.3.5 (July 23, 2020)
+
+### Fixed
+- An example in the README failing to compile (#132)
+
+### Changed
+- Updated `scoped-tls` to 1.0.0 (#153)
+
+### Added
+- `Send` and `Sync` impls for `JoinHandle` (#145)
+- `Default` impls for `Mutex`, `RwLock`, and `Condvar` (#138)
+
 # 0.3.4 (May 2, 2020)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ name = "loom"
 #   - Cargo.toml
 #   - README.md
 # - Create git tag
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Permutation testing for concurrent code"
-documentation = "https://docs.rs/loom/0.3.4/loom"
+documentation = "https://docs.rs/loom/0.3.5/loom"
 homepage = "https://github.com/tokio-rs/loom"
 repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/loom/0.3.4")]
+#![doc(html_root_url = "https://docs.rs/loom/0.3.5")]
 #![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![cfg_attr(loom_nightly, feature(track_caller))]
 

--- a/src/rt/notify.rs
+++ b/src/rt/notify.rs
@@ -90,7 +90,7 @@ impl Notify {
                 state.did_spur = true;
             }
 
-            (state.notified, spurious)
+            dbg!((state.notified, spurious))
         });
 
         if spurious {


### PR DESCRIPTION
Fixed
- An example in the README failing to compile (#132)

Changed
- Updated `scoped-tls` to 1.0.0 (#153)

Added
- `Send` and `Sync` impls for `JoinHandle` (#145)
- `Default` impls for `Mutex`, `RwLock`, and `Condvar` (#138)