### PR TITLE
Partially implement thread::{Thread,ThreadId}

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -62,18 +62,18 @@ pub(crate) const MAX_THREADS: usize = 4;
 /// Maximum number of atomic store history to track per-cell.
 pub(crate) const MAX_ATOMIC_HISTORY: usize = 7;
 
-pub fn spawn<F>(f: F)
+pub(crate) fn spawn<F>(f: F) -> crate::rt::thread::Id
 where
     F: FnOnce() + 'static,
 {
-    execution(|execution| {
-        execution.new_thread();
-    });
+    let id = execution(|execution| execution.new_thread());
 
     Scheduler::spawn(Box::new(move || {
         f();
         thread_done();
     }));
+
+    id
 }
 
 /// Marks the current thread as blocked

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -54,6 +54,14 @@ pub(crate) struct Id {
     id: usize,
 }
 
+impl Id {
+    /// Returns an integer ID unique to this current execution (for use in
+    /// [`thread::ThreadId`]'s `Debug` impl)
+    pub(crate) fn public_id(&self) -> usize {
+        self.id
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum State {
     Runnable,


### PR DESCRIPTION
This implements Thread and ThreadId, with the exception of the park() and
unpark() APIs.