### PR TITLE
Add a `loom::hint` module containing mocked versions of `spin_loop` and `unreachable_unchecked`

### DIFF
--- a/src/hint.rs
+++ b/src/hint.rs
@@ -1,0 +1,15 @@
+//! Mocked versions of [`std::hint`] functions.
+
+/// Signals the processor that it is entering a busy-wait spin-loop.
+pub fn spin_loop() {
+    crate::sync::atomic::spin_loop_hint();
+}
+
+/// Informs the compiler that this point in the code is not reachable, enabling
+/// further optimizations.
+///
+/// Loom's wrapper of this function unconditionally panics.
+#[track_caller]
+pub unsafe fn unreachable_unchecked() -> ! {
+    unreachable!("unreachable_unchecked was reached!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ mod rt;
 
 pub mod alloc;
 pub mod cell;
+pub mod hint;
 pub mod lazy_static;
 pub mod model;
 pub mod sync;


### PR DESCRIPTION
`std::sync::atomic::spin_loop_hint` is deprecated, so loom should provide the non-deprecated replacement. It just calls the deprecated version though.

I provided `unreachable_unchecked` too, even though it's not *exactly* `loom`'s wheelhouse, but it could help catch some UB, and lets users potentially reduce the amount of `cfg` special-casing they need.