### PR TITLE
Add fetch_update to atomics

### DIFF
--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -90,6 +90,22 @@ impl AtomicBool {
     pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
         self.0.rmw(|v| v ^ val, order)
     }
+
+    /// Fetches the value, and applies a function to it that returns an optional new value. Returns
+    /// a [`Result`] of [`Ok`]`(previous_value)` if the function returned [`Some`]`(_)`, else
+    /// [`Err`]`(previous_value)`.
+    #[track_caller]
+    pub fn fetch_update<F>(
+        &self,
+        set_order: Ordering,
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<bool, bool>
+    where
+        F: FnMut(bool) -> Option<bool>,
+    {
+        self.0.fetch_update(set_order, fetch_order, f)
+    }
 }
 
 impl Default for AtomicBool {

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -121,6 +121,22 @@ macro_rules! atomic_int {
             pub fn fetch_xor(&self, val: $atomic_type, order: Ordering) -> $atomic_type {
                 self.0.rmw(|v| v ^ val, order)
             }
+
+            /// Fetches the value, and applies a function to it that returns an optional new value.
+            /// Returns a [`Result`] of [`Ok`]`(previous_value)` if the function returned
+            /// [`Some`]`(_)`, else [`Err`]`(previous_value)`.
+            #[track_caller]
+            pub fn fetch_update<F>(
+                &self,
+                set_order: Ordering,
+                fetch_order: Ordering,
+                f: F,
+            ) -> Result<$atomic_type, $atomic_type>
+            where
+                F: FnMut($atomic_type) -> Option<$atomic_type>,
+            {
+                self.0.fetch_update(set_order, fetch_order, f)
+            }
         }
 
         impl Default for $name {

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -71,6 +71,22 @@ impl<T> AtomicPtr<T> {
     ) -> Result<*mut T, *mut T> {
         self.compare_exchange(current, new, success, failure)
     }
+
+    /// Fetches the value, and applies a function to it that returns an optional new value. Returns
+    /// a [`Result`] of [`Ok`]`(previous_value)` if the function returned [`Some`]`(_)`, else
+    /// [`Err`]`(previous_value)`.
+    #[track_caller]
+    pub fn fetch_update<F>(
+        &self,
+        set_order: Ordering,
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<*mut T, *mut T>
+    where
+        F: FnMut(*mut T) -> Option<*mut T>,
+    {
+        self.0.fetch_update(set_order, fetch_order, f)
+    }
 }
 
 impl<T> Default for AtomicPtr<T> {

--- a/tests/atomic_int.rs
+++ b/tests/atomic_int.rs
@@ -51,6 +51,19 @@ macro_rules! test_int {
                     assert_eq!(b, atomic.load(SeqCst));
                 });
             }
+
+            #[test]
+            fn fetch_update() {
+                loom::model(|| {
+                    let a: $int = NUM_A as $int;
+                    let b: $int = NUM_B as $int;
+
+                    let atomic = <$atomic>::new(a);
+                    assert_eq!(Ok(a), atomic.fetch_update(SeqCst, SeqCst, |_| Some(b)));
+                    assert_eq!(Err(b), atomic.fetch_update(SeqCst, SeqCst, |_| None));
+                    assert_eq!(b, atomic.load(SeqCst));
+                });
+            }
         }
     };
 }


### PR DESCRIPTION
`fetch_update` is useful for implementing CAS loops with less code.