### PR TITLE
chore: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.5.0 (April 12, 2021)
+
+### Breaking
+
+- Bump MSRV to 1.51 (#205)
+
+### Added
+
+- Add `From` implementation to `Mutex` (#131)
+- Add `From` implementation to `RwLock` (#209)
+- Add `From` implementation to atomic types (#210)
+- Add `fetch_update` to atomics (#212)
+
+### Changed
+
+- Move `futures-util` to `dev-dependencies` (#208)
+- Update `generator` to 0.7 (#203)
+
+# 0.4.1 (April 1, 2021)
+
+### Added
+
+- Add a `loom::hint` module containing mocked versions of `spin_loop` and `unreachable_unchecked`. (#197)
+
+### Changed
+
+- Switch to non-deprecated `compare_exchange` (#201)
+
 # 0.4.0 (December 3, 2020)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"
 keywords = ["atomic", "lock-free"]
 categories = ["concurrency", "data-structures"]
-publish = false
 
 [features]
 default = []


### PR DESCRIPTION
Note: The `Cargo.toml` had already been changed in a previous commit.

# 0.5.0 (April 12, 2021)

### Breaking

- Bump MSRV to 1.51 (#205)

### Added

- Add `From` implementation to `Mutex` (#131)
- Add `From` implementation to `RwLock` (#209)
- Add `From` implementation to atomic types (#210)
- Add `fetch_update` to atomics (#212)

### Changed

- Move `futures-util` to `dev-dependencies` (#208)
- Update `generator` to 0.7 (#203)