### PR TITLE
Implement `Mutex::into_inner` and `RwLock::into_inner`

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -55,6 +55,11 @@ impl<T> Mutex<T> {
             Err(TryLockError::WouldBlock)
         }
     }
+
+    /// Consumes this mutex, returning the underlying data.
+    pub fn into_inner(self) -> LockResult<T> {
+        Ok(self.data.into_inner().unwrap())
+    }
 }
 
 impl<T: ?Sized + Default> Default for Mutex<T> {

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -104,7 +104,7 @@ impl<T> RwLock<T> {
 
     /// Consumes this `RwLock`, returning the underlying data.
     pub fn into_inner(self) -> LockResult<T> {
-        unimplemented!()
+        Ok(self.data.into_inner().expect("loom::RwLock state corrupt"))
     }
 }
 


### PR DESCRIPTION
These are pretty easy to implement as they both move the lock itself, so
there's no concurrency to think about.
