### PR TITLE
Prepare v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.1 (July 2, 2021)
+
+### Added
+
+- Add several methods to atomic integer types (#217)
+
 # 0.5.0 (April 12, 2021)
 
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "loom"
 #   - Cargo.toml
 #   - README.md
 # - Create git tag
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Permutation testing for concurrent code"
-documentation = "https://docs.rs/loom/0.5.0/loom"
+documentation = "https://docs.rs/loom/0.5.1/loom"
 homepage = "https://github.com/tokio-rs/loom"
 repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"


### PR DESCRIPTION
# 0.5.1 (July 2, 2021)

### Added

- Add several methods to atomic integer types (#217)