### PR TITLE
Implement `Release`, `AcqRel`, and `SeqCst` fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Then, run the test with
 RUSTFLAGS="--cfg loom" cargo test --test buggy_concurrent_inc --release
 ```
 
+## Unsupported features
+Loom currently does not implement the full C11 memory model.
+Here is the (incomplete) list of unsupported features.
+* `SeqCst` accesses (e.g. `load`, `store`, ..):
+  They are are regarded as `AcqRel`. That is, they impose weaker
+  synchronization, causing Loom to generate false alarms (not complete). See
+  [#180](https://github.com/tokio-rs/loom/issues/180) for example. On the other
+  hand, `fence(SeqCst)` is supported.
+* Load buffering behavior:
+  Loom does not explore some executions that are possible in the C11 memory
+  model. That is, there can be a bug in the checked code even if Loom says
+  there is no bug (not sound).  See the `load_buffering` test case in
+  `tests/litmus.rs`.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ techniques][cdschecker] to avoid combinatorial explosion.
 
 [docs]: https://docs.rs/loom
 [spec]: https://en.cppreference.com/w/cpp/atomic/memory_order
-[cdschecker]: http://demsky.eecs.uci.edu/publications/c11modelcheck.pdf
+[cdschecker]: http://plrg.eecs.uci.edu/publications/toplas16.pdf
 
 ## Quickstart
 

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -203,7 +203,7 @@ fn fence_acqrel(execution: &mut Execution) {
 
 fn fence_seqcst(execution: &mut Execution) {
     fence_acqrel(execution);
-    // TODO do seq_cst stuff
+    execution.threads.seq_cst_fence();
 }
 
 impl<T: Numeric> Atomic<T> {

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -1,33 +1,58 @@
 //! An atomic cell
 //!
-//! # Coherence
+//! See the CDSChecker paper for detailed explanation.
 //!
-//! The coherence rules are implemented as follows.
+//! # Modification order implications (figure 7)
 //!
-//! - Read-Read:
+//! - Read-Read Coherence:
 //!
 //!   On `load`, all stores are iterated, finding stores that were read by
 //!   actions in the current thread's causality. These loads happen-before the
 //!   current load. The `modification_order` of these happen-before loads are
 //!   joined into the current load's `modification_order`.
 //!
-//! - Write-Read:
+//! - Write-Read Coherence:
 //!
 //!   On `load`, all stores are iterated, finding stores that happens-before the
 //!   current thread's causality. The `modification_order` of these stores are
 //!   joined into the current load's `modification_order`.
 //!
-//! - Read-Write:
+//! - Read-Write Coherence:
 //!
 //!   On `store`, find all existing stores that were read in the current
 //!   thread's causality. Join these stores' `modification_order` into the new
 //!   store's modification order.
 //!
-//! - Write-Write:
+//! - Write-Write Coherence:
 //!
 //!   The `modification_order` is initialized to the thread's causality. Any
 //!   store that happened in the thread causality will be earlier in the
 //!   modification order.
+//!
+//! - Seq-cst/MO Consistency:
+//!
+//! - Seq-cst Write-Read Coherence:
+//!
+//! - RMW/MO Consistency: Subsumed by Write-Write Coherence?
+//!
+//! - RMW Atomicity:
+//!
+//!
+//! # Fence modification order implications (figure 9)
+//!
+//! - SC Fences Restrict RF:
+//! - SC Fences Restrict RF (Collapsed Store):
+//! - SC Fences Restrict RF (Collapsed Load):
+//! - SC Fences Impose MO:
+//! - SC Fences Impose MO (Collapsed 1st Store):
+//! - SC Fences Impose MO (Collapsed 2st Store):
+//!
+//!
+//! # Fence Synchronization implications (figure 10)
+//!
+//! - Fence Synchronization
+//! - Fence Synchronization (Collapsed Store)
+//! - Fence Synchronization (Collapsed Load)
 
 use crate::rt::location::{self, Location, LocationSet};
 use crate::rt::object;
@@ -688,6 +713,7 @@ impl State {
                 let mo_i = store_i.modification_order;
                 let mo_j = store_j.modification_order;
 
+                // TODO: this sometimes fails
                 assert_ne!(mo_i, mo_j);
 
                 if mo_i < mo_j {

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -37,6 +37,7 @@ impl Synchronize {
     }
 
     pub fn sync_store(&mut self, threads: &mut thread::Set, order: Ordering) {
+        self.happens_before.join(&threads.active().released);
         match order {
             Relaxed | Acquire => {
                 // Nothing happens!

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -278,8 +278,25 @@ impl Set {
     }
 
     /// Insert a point of sequential consistency
+    /// TODO
+    /// - Deprecate SeqCst accesses and allow SeqCst fences only. The semantics of SeqCst accesses
+    ///   is complex and difficult to implement correctly. On the other hand, SeqCst fence has
+    ///   well-understood and clear semantics in the absence of SeqCst accesses, and can be used
+    ///   for enforcing the read-after-write (RAW) ordering which is probably what the user want to
+    ///   achieve with SeqCst.
+    /// - Revisit the other uses of this function. They probably don't require sequential
+    ///   consistency. E.g. see https://en.cppreference.com/w/cpp/named_req/Mutex
+    ///
+    /// References
+    /// - The "scfix" paper, which proposes a memory model called RC11 that fixes SeqCst
+    ///   semantics. of C11. https://plv.mpi-sws.org/scfix/
+    /// - Some fixes from the "scfix" paper has been incorporated into C/C++20:
+    ///   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0668r5.html
+    /// - The "promising semantics" paper, which propose an intuitive semantics of SeqCst fence in
+    ///   the absence of SC accesses. https://sf.snu.ac.kr/promise-concurrency/
     pub(crate) fn seq_cst(&mut self) {
-        // The previous implementation of sequential consistency was incorrect.
+        // The previous implementation of sequential consistency was incorrect (though it's correct
+        // for `fence(SeqCst)`-only scenario; use `seq_cst_fence` for `fence(SeqCst)`).
         // As a quick fix, just disable it. This may fail to model correct code,
         // but will not silently allow bugs.
     }

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -284,6 +284,14 @@ impl Set {
         // but will not silently allow bugs.
     }
 
+    pub(crate) fn seq_cst_fence(&mut self) {
+        self.threads[self.active.unwrap()]
+            .causality
+            .join(&self.seq_cst_causality);
+        self.seq_cst_causality
+            .join(&self.threads[self.active.unwrap()].causality);
+    }
+
     pub(crate) fn clear(&mut self, execution_id: execution::Id) {
         self.threads.clear();
         self.threads.push(Thread::new(Id::new(execution_id, 0)));

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -18,6 +18,9 @@ pub(crate) struct Thread {
     /// Tracks observed causality
     pub causality: VersionVec,
 
+    /// Tracks the the view of the lastest release fence
+    pub released: VersionVec,
+
     /// Tracks DPOR relations
     pub dpor_vv: VersionVec,
 
@@ -85,6 +88,7 @@ impl Thread {
             critical: false,
             operation: None,
             causality: VersionVec::new(),
+            released: VersionVec::new(),
             dpor_vv: VersionVec::new(),
             last_yield: None,
             yield_count: 0,
@@ -168,6 +172,7 @@ impl fmt::Debug for Thread {
             .field("critical", &self.critical)
             .field("operation", &self.operation)
             .field("causality", &self.causality)
+            .field("released", &self.released)
             .field("dpor_vv", &self.dpor_vv)
             .field("last_yield", &self.last_yield)
             .field("yield_count", &self.yield_count)

--- a/tests/atomic.rs
+++ b/tests/atomic.rs
@@ -108,3 +108,18 @@ fn compare_and_swap_reads_old_values() {
         }
     });
 }
+
+#[test]
+fn fetch_add_atomic() {
+    loom::model(|| {
+        let a1 = Arc::new(AtomicUsize::new(0));
+        let a2 = a1.clone();
+
+        let th = thread::spawn(move || a2.fetch_add(1, Relaxed));
+
+        let v1 = a1.fetch_add(1, Relaxed);
+        let v2 = th.join().unwrap();
+
+        assert_ne!(v1, v2);
+    });
+}

--- a/tests/fence.rs
+++ b/tests/fence.rs
@@ -1,33 +1,106 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use loom::cell::UnsafeCell;
-use loom::sync::atomic::{fence, AtomicUsize};
+use loom::sync::atomic::{fence, AtomicBool};
 use loom::thread;
 
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use std::sync::Arc;
 
 #[test]
-fn basic_acquire_fence() {
+fn fence_sw_base() {
     loom::model(|| {
-        let state1 = Arc::new((UnsafeCell::new(0), AtomicUsize::new(0)));
-        let state2 = state1.clone();
+        let data = Arc::new(UnsafeCell::new(0));
+        let flag = Arc::new(AtomicBool::new(false));
 
-        let th = thread::spawn(move || {
-            state2.0.with_mut(|ptr| unsafe { *ptr = 1 });
-            state2.1.store(1, Release);
-        });
+        let th = {
+            let (data, flag) = (data.clone(), flag.clone());
+            thread::spawn(move || {
+                data.with_mut(|ptr| unsafe { *ptr = 42 });
+                fence(Release);
+                flag.store(true, Relaxed);
+            })
+        };
 
-        loop {
-            if 1 == state1.1.load(Relaxed) {
-                fence(Acquire);
+        if flag.load(Relaxed) {
+            fence(Acquire);
+            assert_eq!(42, data.with_mut(|ptr| unsafe { *ptr }));
+        }
+        th.join().unwrap();
+    });
+}
 
-                let v = unsafe { state1.0.with(|ptr| *ptr) };
-                assert_eq!(1, v);
-                break;
-            }
+#[test]
+fn fence_sw_collapsed_store() {
+    loom::model(|| {
+        let data = Arc::new(UnsafeCell::new(0));
+        let flag = Arc::new(AtomicBool::new(false));
 
-            thread::yield_now();
+        let th = {
+            let (data, flag) = (data.clone(), flag.clone());
+            thread::spawn(move || {
+                data.with_mut(|ptr| unsafe { *ptr = 42 });
+                flag.store(true, Release);
+            })
+        };
+
+        if flag.load(Relaxed) {
+            fence(Acquire);
+            assert_eq!(42, data.with_mut(|ptr| unsafe { *ptr }));
+        }
+        th.join().unwrap();
+    });
+}
+
+#[test]
+fn fence_sw_collapsed_load() {
+    loom::model(|| {
+        let data = Arc::new(UnsafeCell::new(0));
+        let flag = Arc::new(AtomicBool::new(false));
+
+        let th = {
+            let (data, flag) = (data.clone(), flag.clone());
+            thread::spawn(move || {
+                data.with_mut(|ptr| unsafe { *ptr = 42 });
+                fence(Release);
+                flag.store(true, Relaxed);
+            })
+        };
+
+        if flag.load(Acquire) {
+            assert_eq!(42, data.with_mut(|ptr| unsafe { *ptr }));
+        }
+        th.join().unwrap();
+    });
+}
+
+#[test]
+fn fence_hazard_pointer() {
+    loom::model(|| {
+        let reachable = Arc::new(AtomicBool::new(true));
+        let protected = Arc::new(AtomicBool::new(false));
+        let allocated = Arc::new(AtomicBool::new(true));
+
+        let th = {
+            let (reachable, protected, allocated) =
+                (reachable.clone(), protected.clone(), allocated.clone());
+            thread::spawn(move || {
+                // put in protected list
+                protected.store(true, Relaxed);
+                fence(SeqCst);
+                // validate, then access
+                if reachable.load(Relaxed) {
+                    assert!(allocated.load(Relaxed));
+                }
+            })
+        };
+
+        // unlink/retire
+        reachable.store(false, Relaxed);
+        fence(SeqCst);
+        // reclaim unprotected
+        if !protected.load(Relaxed) {
+            allocated.store(false, Relaxed);
         }
 
         th.join().unwrap();

--- a/tests/litmus.rs
+++ b/tests/litmus.rs
@@ -1,0 +1,59 @@
+#![deny(warnings, rust_2018_idioms)]
+
+use loom::sync::atomic::AtomicUsize;
+use loom::thread;
+
+use std::collections::HashSet;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Arc, Mutex};
+
+// Loom currently does not support load buffering.
+#[test]
+#[ignore]
+fn load_buffering() {
+    let values = Arc::new(Mutex::new(HashSet::new()));
+    let values_ = values.clone();
+    loom::model(move || {
+        let x = Arc::new(AtomicUsize::new(0));
+        let y = Arc::new(AtomicUsize::new(0));
+
+        let th = {
+            let (x, y) = (x.clone(), y.clone());
+            thread::spawn(move || {
+                x.store(y.load(Relaxed), Relaxed);
+            })
+        };
+
+        let a = x.load(Relaxed);
+        y.store(1, Relaxed);
+
+        th.join().unwrap();
+        values.lock().unwrap().insert(a);
+    });
+    assert!(values_.lock().unwrap().contains(&1));
+}
+
+#[test]
+fn store_buffering() {
+    let values = Arc::new(Mutex::new(HashSet::new()));
+    let values_ = values.clone();
+    loom::model(move || {
+        let x = Arc::new(AtomicUsize::new(0));
+        let y = Arc::new(AtomicUsize::new(0));
+
+        let a = {
+            let (x, y) = (x.clone(), y.clone());
+            thread::spawn(move || {
+                x.store(1, Relaxed);
+                y.load(Relaxed)
+            })
+        };
+
+        y.store(1, Relaxed);
+        let b = x.load(Relaxed);
+
+        let a = a.join().unwrap();
+        values.lock().unwrap().insert((a, b));
+    });
+    assert!(values_.lock().unwrap().contains(&(0, 0)));
+}


### PR DESCRIPTION
This PR implements `Release`, `AcqRel`, and `SeqCst` fences. 

* `Release` fence can be implemented by recording the `causality` of the thread, which is joined with the later stores (see `released: VersionVec`).
* `AcqRel` fence is `Acquire` fence + `Release` fence.
* `SeqCst` fence uses the old implementation of `SeqCst`, which was removed in #108 for being too strong. However, that implementation is the correct if `SeqCst` is used only for fences. Please see https://github.com/tokio-rs/loom/issues/180#issuecomment-903264839 for more information.

Partially addresses #180
cc: @jeehoonkang @wvwwvwwv 