### PR TITLE
Remove implicit `T: Sized` requirement from `UnsafeCell`

### DIFF
--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -6,7 +6,7 @@ use crate::rt;
 /// `with` and `with_mut`. Both functions take a closure in order to track the
 /// start and end of the access to the underlying cell.
 #[derive(Debug)]
-pub struct UnsafeCell<T> {
+pub struct UnsafeCell<T: ?Sized> {
     /// Causality associated with the cell
     state: rt::Cell,
     data: std::cell::UnsafeCell<T>,
@@ -23,7 +23,9 @@ impl<T> UnsafeCell<T> {
             data: std::cell::UnsafeCell::new(data),
         }
     }
+}
 
+impl<T: ?Sized> UnsafeCell<T> {
     /// Get an immutable pointer to the wrapped value.
     ///
     /// # Panics


### PR DESCRIPTION
`std`'s `UnsafeCell`﻿ doesn't have `T: Sized` requirement, so I don't see why the `loom` version should be different.