### PR TITLE
Remove (implicit) `T: Sized` bound from `Arc`

### DIFF
--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -24,6 +24,8 @@ pub(crate) struct Execution {
     /// Maps raw allocations to LeakTrack objects
     pub(super) raw_allocations: HashMap<usize, Allocation>,
 
+    pub(crate) arc_objs: HashMap<*const (), std::sync::Arc<super::Arc>>,
+
     /// Maximum number of concurrent threads
     pub(super) max_threads: usize,
 
@@ -62,6 +64,7 @@ impl Execution {
             lazy_statics: lazy_static::Set::new(),
             objects: object::Store::with_capacity(max_branches),
             raw_allocations: HashMap::new(),
+            arc_objs: HashMap::new(),
             max_threads,
             max_history: 7,
             location: false,
@@ -98,6 +101,7 @@ impl Execution {
         let mut objects = self.objects;
         let mut lazy_statics = self.lazy_statics;
         let mut raw_allocations = self.raw_allocations;
+        let mut arc_objs = self.arc_objs;
 
         let mut threads = self.threads;
 
@@ -108,6 +112,7 @@ impl Execution {
         objects.clear();
         lazy_statics.reset();
         raw_allocations.clear();
+        arc_objs.clear();
 
         threads.clear(id);
 
@@ -118,6 +123,7 @@ impl Execution {
             objects,
             lazy_statics,
             raw_allocations,
+            arc_objs,
             max_threads,
             max_history,
             location,

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -33,7 +33,7 @@ impl<T> Arc<T> {
 impl<T: ?Sized> Arc<T> {
     /// Converts `std::sync::Arc` to `loom::sync::Arc`
     ///
-    /// This is needed to create `Arc<T>` where `T: !Sized`
+    /// This is needed to create a `loom::sync::Arc<T>` where `T: !Sized`
     ///
     /// ## Panics
     ///

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -37,7 +37,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// ## Panics
     ///
-    /// If the provided arc has copies (ie if it is not unique).
+    /// If the provided `Arc` has copies (i.e., if it is not unique).
     ///
     /// ## Examples
     ///
@@ -45,7 +45,7 @@ impl<T: ?Sized> Arc<T> {
     /// use loom::sync::Arc;
     ///
     /// # loom::model::model(|| {
-    /// // std's arc can be automatcally coerced
+    /// // std's arc can be automatically coerced
     /// let std = std::sync::Arc::new([1, 2, 3]);
     /// let loom: Arc<[u8]> = Arc::from_std(std);
     ///

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -189,6 +189,12 @@ impl<T: ?Sized> Drop for Arc<T> {
                 std::sync::Arc::strong_count(&self.inner),
                 "something odd is going on"
             );
+
+            rt::execution(|e| {
+                e.arc_objs
+                    .remove(&std::sync::Arc::as_ptr(&self.inner).cast())
+                    .expect("Arc object was removed before dropping last Arc");
+            });
         }
     }
 }


### PR DESCRIPTION
This is an attempt to resolve #85