### PR TITLE
Arc::as_ptr

### DIFF
--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -81,8 +81,7 @@ impl<T> Arc<T> {
 
     /// Provides a raw pointer to the data.
     pub fn as_ptr(this: &Self) -> *const T {
-        let ptr = &*this as *const _;
-        ptr as *const T
+        std::sync::Arc::as_ptr(&this.inner) as *const T
     }
 
     /// Constructs an `Arc` from a raw pointer.

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -74,7 +74,7 @@ impl<T> Arc<T> {
 
     /// Consumes the `Arc`, returning the wrapped pointer.
     pub fn into_raw(this: Self) -> *const T {
-        let ptr = as_ptr(&this);
+        let ptr = Self::as_ptr(&this);
         mem::forget(this);
         ptr
     }

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -74,8 +74,14 @@ impl<T> Arc<T> {
 
     /// Consumes the `Arc`, returning the wrapped pointer.
     pub fn into_raw(this: Self) -> *const T {
-        let ptr = &*this as *const _;
+        let ptr = as_ptr(&this);
         mem::forget(this);
+        ptr
+    }
+
+    /// Provides a raw pointer to the data.
+    pub fn as_ptr(this: &Self) -> *const T {
+        let ptr = &*this as *const _;
         ptr as *const T
     }
 


### PR DESCRIPTION
This PR adds `Arc::as_ptr(&Self)`.