### PR TITLE
fix a bunch of annoying clippy lints

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -5,6 +5,20 @@ use crate::rt;
 pub use std::alloc::Layout;
 
 /// Allocate memory with the global allocator.
+///
+/// This is equivalent to the standard library's [`std::alloc::alloc`], but with
+/// the addition of leak tracking for allocated objects. Loom's leak tracking
+/// will not function for allocations not performed via this method.
+///
+/// This function forwards calls to the [`GlobalAlloc::alloc`] method
+/// of the allocator registered with the `#[global_allocator]` attribute
+/// if there is one, or the `std` crate’s default.
+///
+/// # Safety
+///
+/// See [`GlobalAlloc::alloc`].
+///
+/// [`GlobalAlloc::alloc`]: std::alloc::GlobalAlloc::alloc
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     let ptr = std::alloc::alloc(layout);
     rt::alloc(ptr);
@@ -12,6 +26,20 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 }
 
 /// Allocate zero-initialized memory with the global allocator.
+///
+/// This is equivalent to the standard library's [`std::alloc::alloc_zeroed`],
+/// but with the addition of leak tracking for allocated objects. Loom's leak
+/// tracking will not function for allocations not performed via this method.
+///
+/// This function forwards calls to the [`GlobalAlloc::alloc_zeroed`] method
+/// of the allocator registered with the `#[global_allocator]` attribute
+/// if there is one, or the `std` crate’s default.
+///
+/// # Safety
+///
+/// See [`GlobalAlloc::alloc_zeroed`].
+///
+/// [`GlobalAlloc::alloc_zeroed`]: std::alloc::GlobalAlloc::alloc_zeroed
 pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
     let ptr = std::alloc::alloc_zeroed(layout);
     rt::alloc(ptr);
@@ -19,6 +47,22 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 }
 
 /// Deallocate memory with the global allocator.
+///
+/// This is equivalent to the standard library's [`std::alloc::dealloc`],
+/// but with the addition of leak tracking for allocated objects. Loom's leak
+/// tracking may report false positives if allocations allocated with
+/// [`loom::alloc::alloc`] or [`loom::alloc::alloc_zeroed`] are deallocated via
+/// [`std::alloc::dealloc`] rather than by this function.
+///
+/// This function forwards calls to the [`GlobalAlloc::dealloc`] method
+/// of the allocator registered with the `#[global_allocator]` attribute
+/// if there is one, or the `std` crate’s default.
+///
+/// # Safety
+///
+/// See [`GlobalAlloc::dealloc`].
+///
+/// [`GlobalAlloc::dealloc`]: std::alloc::GlobalAlloc::dealloc
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
     rt::dealloc(ptr);
     std::alloc::dealloc(ptr, layout)

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -1,5 +1,6 @@
 //! Shareable mutable containers.
 
+#[allow(clippy::module_inception)]
 mod cell;
 mod unsafe_cell;
 

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -21,14 +21,14 @@ where
 
     let notify = Arc::new(rt::Notify::new(false, true));
 
-    let mut waker = unsafe {
+    let waker = unsafe {
         mem::ManuallyDrop::new(Waker::from_raw(RawWaker::new(
             &*notify as *const _ as *const (),
             waker_vtable(),
         )))
     };
 
-    let mut cx = Context::from_waker(&mut waker);
+    let mut cx = Context::from_waker(&waker);
 
     loop {
         match f.as_mut().poll(&mut cx) {

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -8,7 +8,20 @@ pub fn spin_loop() {
 /// Informs the compiler that this point in the code is not reachable, enabling
 /// further optimizations.
 ///
-/// Loom's wrapper of this function unconditionally panics.
+/// This is a mocked version of the standard library's
+/// [`std::hint::unreachable_unchecked`]. Loom's wrapper of this function
+/// unconditionally panics.
+///
+/// # Safety
+///
+/// Technically, this function is safe to call (unlike the standard library's
+/// version), as it always panics rather than invoking UB. However, this
+/// function is marked as `unsafe` because it's intended to be used as a
+/// simulated version of [`std::hint::unreachable_unchecked`], which is unsafe.
+///
+/// See [the documentation for
+/// `std::hint::unreachable_unchecked`](`std::hint::unreachable_unchecked#Safety)
+/// for safety details.
 #[track_caller]
 pub unsafe fn unreachable_unchecked() -> ! {
     unreachable!("unreachable_unchecked was reached!");

--- a/src/model.rs
+++ b/src/model.rs
@@ -77,17 +77,12 @@ impl Builder {
         let checkpoint_interval = env::var("LOOM_CHECKPOINT_INTERVAL")
             .map(|v| {
                 v.parse()
-                    .ok()
                     .expect("invalid value for `LOOM_CHECKPOINT_INTERVAL`")
             })
             .unwrap_or(20_000);
 
         let max_branches = env::var("LOOM_MAX_BRANCHES")
-            .map(|v| {
-                v.parse()
-                    .ok()
-                    .expect("invalid value for `LOOM_MAX_BRANCHES`")
-            })
+            .map(|v| v.parse().expect("invalid value for `LOOM_MAX_BRANCHES`"))
             .unwrap_or(DEFAULT_MAX_BRANCHES);
 
         let location = env::var("LOOM_LOCATION").is_ok();
@@ -96,10 +91,7 @@ impl Builder {
 
         let max_duration = env::var("LOOM_MAX_DURATION")
             .map(|v| {
-                let secs = v
-                    .parse()
-                    .ok()
-                    .expect("invalid value for `LOOM_MAX_DURATION`");
+                let secs = v.parse().expect("invalid value for `LOOM_MAX_DURATION`");
                 Duration::from_secs(secs)
             })
             .ok();
@@ -107,25 +99,16 @@ impl Builder {
         let max_permutations = env::var("LOOM_MAX_PERMUTATIONS")
             .map(|v| {
                 v.parse()
-                    .ok()
                     .expect("invalid value for `LOOM_MAX_PERMUTATIONS`")
             })
             .ok();
 
         let preemption_bound = env::var("LOOM_MAX_PREEMPTIONS")
-            .map(|v| {
-                v.parse()
-                    .ok()
-                    .expect("invalid value for `LOOM_MAX_PREEMPTIONS`")
-            })
+            .map(|v| v.parse().expect("invalid value for `LOOM_MAX_PREEMPTIONS`"))
             .ok();
 
         let checkpoint_file = env::var("LOOM_CHECKPOINT_FILE")
-            .map(|v| {
-                v.parse()
-                    .ok()
-                    .expect("invalid value for `LOOM_CHECKPOINT_FILE`")
-            })
+            .map(|v| v.parse().expect("invalid value for `LOOM_CHECKPOINT_FILE`"))
             .ok();
 
         Builder {

--- a/src/model.rs
+++ b/src/model.rs
@@ -203,6 +203,12 @@ impl Builder {
     }
 }
 
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Run all concurrent permutations of the provided closure.
 ///
 /// Uses a default [`Builder`](crate::model::Builder) which can be affected

--- a/src/model.rs
+++ b/src/model.rs
@@ -13,6 +13,7 @@ const DEFAULT_MAX_BRANCHES: usize = 1_000;
 
 /// Configure a model
 #[derive(Debug)]
+#[non_exhaustive] // Support adding more fields in the future
 pub struct Builder {
     /// Max number of threads to check as part of the execution.
     ///
@@ -64,9 +65,6 @@ pub struct Builder {
     ///
     /// Defaults to existence of `LOOM_LOG` environment variable.
     pub log: bool,
-
-    // Support adding more fields in the future
-    _p: (),
 }
 
 impl Builder {
@@ -121,7 +119,6 @@ impl Builder {
             checkpoint_interval,
             location,
             log,
-            _p: (),
         }
     }
 

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -10,13 +10,13 @@ impl Access {
     pub(crate) fn new(path_id: usize, version: &VersionVec) -> Access {
         Access {
             path_id,
-            dpor_vv: version.clone(),
+            dpor_vv: *version,
         }
     }
 
     pub(crate) fn set(&mut self, path_id: usize, version: &VersionVec) {
         self.path_id = path_id;
-        self.dpor_vv = version.clone();
+        self.dpor_vv = *version;
     }
 
     pub(crate) fn set_or_create(access: &mut Option<Self>, path_id: usize, version: &VersionVec) {

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -904,10 +904,7 @@ impl FirstSeen {
 }
 
 fn is_seq_cst(order: Ordering) -> bool {
-    match order {
-        Ordering::SeqCst => true,
-        _ => false,
-    }
+    order == Ordering::SeqCst
 }
 
 fn range(cnt: u16) -> (usize, usize) {

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -468,7 +468,7 @@ impl State {
         // The modification order is initialized to the thread's current
         // causality. All reads / writes that happen before this store are
         // ordered before the store.
-        let happens_before = threads.active().causality.clone();
+        let happens_before = threads.active().causality;
 
         // Starting with the thread's causality covers WRITE-WRITE coherence
         let mut modification_order = happens_before;

--- a/src/rt/cell.rs
+++ b/src/rt/cell.rs
@@ -120,15 +120,15 @@ impl Cell {
 
 impl State {
     fn new(threads: &thread::Set, location: Location) -> State {
-        let version = threads.active().causality.clone();
+        let version = threads.active().causality;
 
         State {
             created_location: location,
             is_reading: 0,
             is_writing: false,
-            read_access: version.clone(),
+            read_access: version,
             read_locations: LocationSet::new(),
-            write_access: version.clone(),
+            write_access: version,
             write_locations: LocationSet::new(),
         }
     }

--- a/src/rt/location.rs
+++ b/src/rt/location.rs
@@ -106,7 +106,7 @@ impl PanicBuilder {
 
                 let th = thread
                     .map(|th| format!("thread #{} @ ", th))
-                    .unwrap_or("".to_string());
+                    .unwrap_or_else(String::new);
 
                 msg.push_str(&format!("\n    {}{}: {}{}", spaces, key, th, location));
             }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -123,8 +123,7 @@ where
     execution(|execution| {
         execution.threads.active_causality_inc();
         trace!("synchronize");
-        let ret = f(execution);
-        ret
+        f(execution)
     })
 }
 

--- a/src/rt/mpsc.rs
+++ b/src/rt/mpsc.rs
@@ -72,7 +72,7 @@ impl Channel {
                 .sync_store(&mut execution.threads, Release);
             state
                 .receiver_synchronize
-                .push_back(state.sender_synchronize.clone());
+                .push_back(state.sender_synchronize);
 
             if state.msg_cnt == 1 {
                 // Unblock all threads that are blocked waiting on this channel

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -387,54 +387,54 @@ impl Operation {
     }
 }
 
-impl Into<rt::arc::Action> for Action {
-    fn into(self) -> rt::arc::Action {
-        match self {
+impl From<Action> for rt::arc::Action {
+    fn from(action: Action) -> Self {
+        match action {
             Action::Arc(action) => action,
             _ => unreachable!(),
         }
     }
 }
 
-impl Into<rt::atomic::Action> for Action {
-    fn into(self) -> rt::atomic::Action {
-        match self {
+impl From<Action> for rt::atomic::Action {
+    fn from(action: Action) -> Self {
+        match action {
             Action::Atomic(action) => action,
             _ => unreachable!(),
         }
     }
 }
 
-impl Into<rt::mpsc::Action> for Action {
-    fn into(self) -> rt::mpsc::Action {
-        match self {
+impl From<Action> for rt::mpsc::Action {
+    fn from(action: Action) -> Self {
+        match action {
             Action::Channel(action) => action,
             _ => unreachable!(),
         }
     }
 }
 
-impl Into<Action> for rt::arc::Action {
-    fn into(self) -> Action {
-        Action::Arc(self)
+impl From<rt::arc::Action> for Action {
+    fn from(action: rt::arc::Action) -> Self {
+        Action::Arc(action)
     }
 }
 
-impl Into<Action> for rt::atomic::Action {
-    fn into(self) -> Action {
-        Action::Atomic(self)
+impl From<rt::atomic::Action> for Action {
+    fn from(action: rt::atomic::Action) -> Self {
+        Action::Atomic(action)
     }
 }
 
-impl Into<Action> for rt::mpsc::Action {
-    fn into(self) -> Action {
-        Action::Channel(self)
+impl From<rt::mpsc::Action> for Action {
+    fn from(action: rt::mpsc::Action) -> Self {
+        Action::Channel(action)
     }
 }
 
-impl Into<Action> for rt::rwlock::Action {
-    fn into(self) -> Action {
-        Action::RwLock(self)
+impl From<rt::rwlock::Action> for Action {
+    fn from(action: rt::rwlock::Action) -> Self {
+        Action::RwLock(action)
     }
 }
 

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -108,6 +108,9 @@ macro_rules! objects {
 
 objects! {
     #[derive(Debug)]
+    // Many of the common variants of this enum are quite large --- only `Entry`
+    // and `Alloc` are significantly smaller than most other variants.
+    #[allow(clippy::large_enum_variant)]
     Entry,
 
     // State tracking allocations. Used for leak detection.

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -181,7 +181,7 @@ impl<T> Store<T> {
         self.entries.clear();
     }
 
-    pub(super) fn iter_ref<'a, O>(&'a self) -> impl DoubleEndedIterator<Item = Ref<O>> + 'a
+    pub(super) fn iter_ref<O>(&self) -> impl DoubleEndedIterator<Item = Ref<O>> + '_
     where
         O: Object<Entry = T>,
     {

--- a/src/rt/path.rs
+++ b/src/rt/path.rs
@@ -280,7 +280,7 @@ impl Path {
             .threads
             .iter()
             .enumerate()
-            .find(|&(_, ref th)| th.is_active())
+            .find(|&(_, th)| th.is_active())
             .map(|(i, _)| thread::Id::new(execution_id, i))
     }
 

--- a/src/rt/path.rs
+++ b/src/rt/path.rs
@@ -405,10 +405,8 @@ impl Schedule {
 
     /// Compute the number of preemptions for the current state of the branch
     fn preemptions(&self) -> u8 {
-        if self.initial_active.is_some() {
-            if self.initial_active != self.active_thread_index() {
-                return self.preemptions + 1;
-            }
+        if self.initial_active.is_some() && self.initial_active != self.active_thread_index() {
+            return self.preemptions + 1;
         }
 
         self.preemptions

--- a/src/rt/path.rs
+++ b/src/rt/path.rs
@@ -452,17 +452,11 @@ impl Thread {
     }
 
     fn is_pending(&self) -> bool {
-        match *self {
-            Thread::Pending => true,
-            _ => false,
-        }
+        *self == Thread::Pending
     }
 
     fn is_active(&self) -> bool {
-        match *self {
-            Thread::Active => true,
-            _ => false,
-        }
+        *self == Thread::Active
     }
 
     fn is_enabled(&self) -> bool {

--- a/src/rt/path.rs
+++ b/src/rt/path.rs
@@ -348,11 +348,9 @@ impl Path {
                 let schedule = schedule_ref.get_mut(&mut self.branches);
 
                 // Transition the active thread to visited.
-                schedule
-                    .threads
-                    .iter_mut()
-                    .find(|th| th.is_active())
-                    .map(|th| *th = Thread::Visited);
+                if let Some(thread) = schedule.threads.iter_mut().find(|th| th.is_active()) {
+                    *thread = Thread::Visited;
+                }
 
                 // Find a pending thread and transition it to active
                 let rem = schedule
@@ -448,11 +446,8 @@ impl Schedule {
 
 impl Thread {
     fn explore(&mut self) {
-        match *self {
-            Thread::Skip => {
-                *self = Thread::Pending;
-            }
-            _ => {}
+        if *self == Thread::Skip {
+            *self = Thread::Pending;
         }
     }
 

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -154,22 +154,18 @@ impl RwLock {
 
     /// Returns `true` if RwLock is read locked
     fn is_read_locked(&self) -> bool {
-        super::execution(
-            |execution| match self.state.get(&mut execution.objects).lock {
-                Some(Locked::Read(_)) => true,
-                _ => false,
-            },
-        )
+        super::execution(|execution| {
+            let lock = &self.state.get(&execution.objects).lock;
+            matches!(lock, Some(Locked::Read(_)))
+        })
     }
 
     /// Returns `true` if RwLock is write locked.
     fn is_write_locked(&self) -> bool {
-        super::execution(
-            |execution| match self.state.get(&mut execution.objects).lock {
-                Some(Locked::Write(_)) => true,
-                _ => false,
-            },
-        )
+        super::execution(|execution| {
+            let lock = &self.state.get(&execution.objects).lock;
+            matches!(lock, Some(Locked::Write(_)))
+        })
     }
 
     fn post_acquire_read_lock(&self) -> bool {

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -110,7 +110,7 @@ impl Scheduler {
 
     fn tick(&mut self, thread: thread::Id, execution: &mut Execution) {
         let state = RefCell::new(State {
-            execution: execution,
+            execution,
             queued_spawn: &mut self.queued_spawn,
         });
 

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -69,8 +69,8 @@ impl Scheduler {
             ptr::null(),
             &RawWakerVTable::new(noop_clone, noop, noop, noop),
         );
-        let mut waker = unsafe { Waker::from_raw(raw_waker) };
-        let mut cx = Context::from_waker(&mut waker);
+        let waker = unsafe { Waker::from_raw(raw_waker) };
+        let mut cx = Context::from_waker(&waker);
 
         assert!(switch.poll(&mut cx).is_ready());
     }

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -262,7 +262,7 @@ impl Set {
 
         // Synchronize memory
         let (active, th) = self.active2_mut(id);
-        th.unpark(&active);
+        th.unpark(active);
     }
 
     /// Insert a point of sequential consistency

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -97,10 +97,7 @@ impl Thread {
     }
 
     pub(crate) fn is_runnable(&self) -> bool {
-        match self.state {
-            State::Runnable => true,
-            _ => false,
-        }
+        matches!(self.state, State::Runnable)
     }
 
     pub(crate) fn set_runnable(&mut self) {
@@ -112,17 +109,11 @@ impl Thread {
     }
 
     pub(crate) fn is_blocked(&self) -> bool {
-        match self.state {
-            State::Blocked => true,
-            _ => false,
-        }
+        matches!(self.state, State::Blocked)
     }
 
     pub(crate) fn is_yield(&self) -> bool {
-        match self.state {
-            State::Yield => true,
-            _ => false,
-        }
+        matches!(self.state, State::Yield)
     }
 
     pub(crate) fn set_yield(&mut self) {
@@ -132,10 +123,7 @@ impl Thread {
     }
 
     pub(crate) fn is_terminated(&self) -> bool {
-        match self.state {
-            State::Terminated => true,
-            _ => false,
-        }
+        matches!(self.state, State::Terminated)
     }
 
     pub(crate) fn set_terminated(&mut self) {

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -306,7 +306,7 @@ impl Set {
         self.seq_cst_causality = VersionVec::new();
     }
 
-    pub(crate) fn iter<'a>(&'a self) -> impl ExactSizeIterator<Item = (Id, &'a Thread)> + 'a {
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = (Id, &Thread)> + '_ {
         let execution_id = self.execution_id;
         self.threads
             .iter()
@@ -314,9 +314,7 @@ impl Set {
             .map(move |(id, thread)| (Id::new(execution_id, id), thread))
     }
 
-    pub(crate) fn iter_mut<'a>(
-        &'a mut self,
-    ) -> impl ExactSizeIterator<Item = (Id, &'a mut Thread)> {
+    pub(crate) fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (Id, &mut Thread)> + '_ {
         let execution_id = self.execution_id;
         self.threads
             .iter_mut()

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -134,7 +134,7 @@ impl Thread {
         let mut locals = Vec::with_capacity(self.locals.len());
 
         // run the Drop impls of any mock thread-locals created by this thread.
-        for (_, local) in &mut self.locals {
+        for local in self.locals.values_mut() {
             locals.push(local.0.take());
         }
 

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -18,10 +18,10 @@ impl VersionVec {
         }
     }
 
-    pub(crate) fn versions<'a>(
-        &'a self,
+    pub(crate) fn versions(
+        &self,
         execution_id: execution::Id,
-    ) -> impl Iterator<Item = (thread::Id, u16)> + 'a {
+    ) -> impl Iterator<Item = (thread::Id, u16)> + '_ {
         self.versions
             .iter()
             .enumerate()

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -59,21 +59,11 @@ impl cmp::PartialOrd for VersionVec {
         for i in 0..MAX_THREADS {
             let a = self.versions[i];
             let b = other.versions[i];
-
-            if a == b {
-                // Keep checking
-            } else if a < b {
-                if ret == Greater {
-                    return None;
-                }
-
-                ret = Less;
-            } else {
-                if ret == Less {
-                    return None;
-                }
-
-                ret = Greater;
+            match a.cmp(&b) {
+                Equal => {}
+                Less if ret == Greater => return None,
+                Greater if ret == Less => return None,
+                ordering => ret = ordering,
             }
         }
 

--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -14,6 +14,13 @@ impl AtomicBool {
     }
 
     /// Load the value without any synchronization.
+    ///
+    /// # Safety
+    ///
+    /// An unsynchronized atomic load technically always has undefined behavior.
+    /// However, if the atomic value is not currently visible by other threads,
+    /// this *should* always be equivalent to a non-atomic load of an un-shared
+    /// `bool` value.
     #[track_caller]
     pub unsafe fn unsync_load(&self) -> bool {
         self.0.unsync_load()

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -34,6 +34,13 @@ macro_rules! atomic_int {
             }
 
             /// Load the value without any synchronization.
+            ///
+            /// # Safety
+            ///
+            /// An unsynchronized atomic load technically always has undefined behavior.
+            /// However, if the atomic value is not currently visible by other threads,
+            /// this *should* always be equivalent to a non-atomic load of an un-shared
+            /// integer value.
             #[track_caller]
             pub unsafe fn unsync_load(&self) -> $atomic_type {
                 self.0.unsync_load()

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -1,5 +1,6 @@
 //! Mock implementation of `std::sync::atomic`.
 
+#[allow(clippy::module_inception)]
 mod atomic;
 use self::atomic::Atomic;
 

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -14,6 +14,13 @@ impl<T> AtomicPtr<T> {
     }
 
     /// Load the value without any synchronization.
+    ///
+    /// # Safety
+    ///
+    /// An unsynchronized atomic load technically always has undefined behavior.
+    /// However, if the atomic value is not currently visible by other threads,
+    /// this *should* always be equivalent to a non-atomic load of an un-shared
+    /// `*mut T` value.
     pub unsafe fn unsync_load(&self) -> *mut T {
         self.0.unsync_load()
     }

--- a/src/sync/notify.rs
+++ b/src/sync/notify.rs
@@ -41,3 +41,9 @@ impl Notify {
         self.waiting.store(false, SeqCst);
     }
 }
+
+impl Default for Notify {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -151,6 +151,9 @@ where
 impl Builder {
     /// Generates the base configuration for spawning a thread, from which
     /// configuration methods can be chained.
+    // `std::thread::Builder` does not implement `Default`, so this type does
+    // not either, as it's a mock version of the `std` type.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Builder {
         Builder { name: None }
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -34,7 +34,7 @@ impl Thread {
 
     /// Returns the (optional) name of this thread
     pub fn name(&self) -> Option<&str> {
-        self.name.as_ref().map(|s| s.as_str())
+        self.name.as_deref()
     }
 }
 

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -23,9 +23,6 @@ fn two_mutexes_deadlock() {
             })
         };
         let th2 = {
-            let a = a.clone();
-            let b = b.clone();
-
             thread::spawn(move || {
                 let b_lock = b.lock().unwrap();
                 let a_lock = a.lock().unwrap();

--- a/tests/fence.rs
+++ b/tests/fence.rs
@@ -138,6 +138,8 @@ fn fence_hazard_pointer() {
 // C/C++20 and all the implementations of C/C++11 disallow this behavior.
 #[test]
 fn rwc_syncs() {
+    // ... what else would you call them?
+    #![allow(clippy::many_single_char_names)]
     loom::model(|| {
         let x = Arc::new(AtomicBool::new(false));
         let y = Arc::new(AtomicBool::new(false));
@@ -177,6 +179,7 @@ fn rwc_syncs() {
 // C/C++20 and most of the implementations of C/C++11 disallow this behavior.
 #[test]
 fn w_rwc() {
+    #![allow(clippy::many_single_char_names)]
     loom::model(|| {
         let x = Arc::new(AtomicBool::new(false));
         let y = Arc::new(AtomicBool::new(false));

--- a/tests/fence.rs
+++ b/tests/fence.rs
@@ -153,7 +153,7 @@ fn rwc_syncs() {
         };
 
         let t3 = {
-            let (x, y) = (x.clone(), y.clone());
+            let x = x.clone();
             thread::spawn(move || {
                 y.store(true, Relaxed);
                 fence(SeqCst);
@@ -193,7 +193,7 @@ fn w_rwc() {
         };
 
         let t3 = {
-            let (x, y) = (x.clone(), y.clone());
+            let x = x.clone();
             thread::spawn(move || {
                 y.store(true, Relaxed);
                 fence(SeqCst);

--- a/tests/rwlock_regression1.rs
+++ b/tests/rwlock_regression1.rs
@@ -11,11 +11,11 @@ fn rwlock_two_writers() {
     loom::model(|| {
         let lock = Arc::new(RwLock::new(1));
         let c_lock = lock.clone();
-        let c_lock2 = lock.clone();
+        let c_lock2 = lock;
 
         let atomic = Arc::new(AtomicUsize::new(0));
         let c_atomic = atomic.clone();
-        let c_atomic2 = atomic.clone();
+        let c_atomic2 = atomic;
 
         thread::spawn(move || {
             let mut w = c_lock.write().unwrap();

--- a/tests/thread_local.rs
+++ b/tests/thread_local.rs
@@ -43,7 +43,7 @@ fn nested_with() {
     }
 
     loom::model(|| {
-        LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| local2.borrow().clone()));
+        LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| *local2.borrow()));
     });
 }
 


### PR DESCRIPTION
This branch fixes a big pile of clippy lints. These are mostly not
particularly important, but they were kinda bugging me, so I thought it
was nice to fix them.

I've tried to separate out each individual lint category into separate
commits, with notes in the commit message as necessary. Most of these
changes are completely trivial, but there are a few that might be worth
actually reviewing in detail. Therefore, each commit can be considered
individually, and if there are any cases where we don't like Clippy's
suggestions, I can back out those commits and add `#[allow(...)]`
attributes instead.

In particular, `clippy` suggested adding
`Default` implementations for a few types. This seems pretty harmless,
but (unlike the rest of this PR) it *is* an actual API change, so if
that's unwanted, I can back out that commit and add `allow` attributes
for the `new_without_default` lint, instead.

I've also added some new documentation to resolve the
`clippy::missing_safety_doc` lint. In most cases, this was on functions
that mimic `std` APIs that are unsafe, so I've copied the `# Safety`
sections from the `std` docs for those functions. In some cases I've
added additional text to the documentation describing differences
between `loom`'s version and `std`'s versions of these functions.