### PR TITLE
chore: prepare loom 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.5.3 (November 23, 2021)
+
+### Added
+
+- thread: Add mock versions of `thread::park` and `Thread::unpark` (#240)
+
+### Changed
+
+- Don't attempt to clean up Mutex when threads are deadlocked (#236)
+- Update tracing-subscriber to 0.3 (#238)
+
 # 0.5.2 (October 7, 2021)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,12 @@ name = "loom"
 # - Update version number
 #   - README.md
 # - Update CHANGELOG.md
-# - Update doc URL.
-#   - Cargo.toml
-#   - README.md
 # - Create git tag
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Permutation testing for concurrent code"
-documentation = "https://docs.rs/loom/0.5.2/loom"
 homepage = "https://github.com/tokio-rs/loom"
 repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"


### PR DESCRIPTION
# 0.5.3 (November 23, 2021)

### Added

- thread: Add mock versions of `thread::park` and `Thread::unpark` (#240)

### Changed

- Don't attempt to clean up Mutex when threads are deadlocked (#236)
- Update tracing-subscriber to 0.3 (#238)