### PR TITLE
Improve error message when execution `STATE` is unavailable

### DIFF
--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -45,7 +45,7 @@ impl Scheduler {
     where
         F: FnOnce(&mut Execution) -> R,
     {
-        STATE.with(|state| f(&mut state.borrow_mut().execution))
+        Self::with_state(|state| f(&mut state.execution))
     }
 
     /// Perform a context switch
@@ -76,9 +76,7 @@ impl Scheduler {
     }
 
     pub(crate) fn spawn(f: Box<dyn FnOnce()>) {
-        STATE.with(|state| {
-            state.borrow_mut().queued_spawn.push_back(f);
-        });
+        Self::with_state(|state| state.queued_spawn.push_back(f));
     }
 
     pub(crate) fn run<F>(&mut self, execution: &mut Execution, f: F)
@@ -119,6 +117,17 @@ impl Scheduler {
         STATE.set(unsafe { transmute_lt(&state) }, || {
             threads[thread.as_usize()].resume();
         });
+    }
+
+    fn with_state<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut State<'_>) -> R,
+    {
+        if !STATE.is_set() {
+            panic!("cannot access Loom execution state from outside a Loom model. \
+            are you accessing a Loom synchronization primitive from outside a Loom test (a call to `model` or `check`)?")
+        }
+        STATE.with(|state| f(&mut state.borrow_mut()))
     }
 }
 


### PR DESCRIPTION
A mistake we sometimes make when working on [a large code base that uses Loom for testing](https://www.amazon.science/publications/using-lightweight-formal-methods-to-validate-a-key-value-storage-node-in-amazon-s3) is messing up our conditional imports, such that either a non-Loom-controlled `std::thread` is constructed or a Loom synchronization primitive is accessed from outside the context of a Loom model.

Here's a simple example distilled from one such mistake I made just now:

```rust
#[test]
fn thing() {
    loom::model(|| {
        let lock = Arc::new(Mutex::new(0));

        let thd = {
            let lock = lock.clone();
            // oops, wrong `thread`, not controlled by loom
            std::thread::spawn(move || {
                *lock.lock().unwrap() += 1;
            })
        };

        thd.join().unwrap();

        let lock = Arc::try_unwrap(lock).unwrap().into_inner().unwrap();
        assert_eq!(lock, 1);
    })
}
```
(Usually, the thread spawn happens in some other piece of code, so the problem is less easy to spot).

When this test fails, it gives a fairly opaque error message from Loom's internals:
```
thread '<unnamed>' panicked at 'cannot access a scoped thread local variable without calling `set` first', /Users/bornholt/.cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-1.0.0/src/lib.rs:168:9
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:543:12
   1: scoped_tls::ScopedKey<T>::with
             at /Users/bornholt/.cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-1.0.0/src/lib.rs:168:9
   2: loom::rt::scheduler::Scheduler::with_execution
             at ./src/rt/scheduler.rs:48:9
   3: loom::rt::execution
             at ./src/rt/mod.rs:156:5
```

This change just gives a more suggestive error message about what's going wrong:
```
thread '<unnamed>' panicked at 'cannot access Loom execution state from outside a Loom model. are you accessing a synchronization primitive from outside a Loom test (a call to `model` or `check`)?', src/rt/scheduler.rs:127:13
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:543:12
   1: loom::rt::scheduler::Scheduler::with_state
             at ./src/rt/scheduler.rs:127:13
   2: loom::rt::scheduler::Scheduler::with_execution
             at ./src/rt/scheduler.rs:48:9
   3: loom::rt::execution
             at ./src/rt/mod.rs:156:5
```