### PR TITLE
chore: fix unused field warnings 

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -72,7 +72,8 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
 #[derive(Debug)]
 pub struct Track<T> {
     value: T,
-    obj: rt::Allocation,
+    /// Drop guard tracking the allocation's lifetime.
+    _obj: rt::Allocation,
 }
 
 impl<T> Track<T> {
@@ -80,7 +81,7 @@ impl<T> Track<T> {
     pub fn new(value: T) -> Track<T> {
         Track {
             value,
-            obj: rt::Allocation::new(),
+            _obj: rt::Allocation::new(),
         }
     }
 

--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -52,7 +52,8 @@ pub struct UnsafeCell<T: ?Sized> {
 /// [here]: #correct-usage
 #[derive(Debug)]
 pub struct ConstPtr<T: ?Sized> {
-    guard: rt::cell::Reading,
+    /// Drop guard representing the lifetime of the `ConstPtr`'s access.
+    _guard: rt::cell::Reading,
     ptr: *const T,
 }
 
@@ -95,7 +96,8 @@ pub struct ConstPtr<T: ?Sized> {
 /// [here]: #correct-usage
 #[derive(Debug)]
 pub struct MutPtr<T: ?Sized> {
-    guard: rt::cell::Writing,
+    /// Drop guard representing the lifetime of the `ConstPtr`'s access.
+    _guard: rt::cell::Writing,
     ptr: *mut T,
 }
 
@@ -162,7 +164,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[track_caller]
     pub fn get(&self) -> ConstPtr<T> {
         ConstPtr {
-            guard: self.state.start_read(location!()),
+            _guard: self.state.start_read(location!()),
             ptr: self.data.get(),
         }
     }
@@ -189,7 +191,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[track_caller]
     pub fn get_mut(&self) -> MutPtr<T> {
         MutPtr {
-            guard: self.state.start_write(location!()),
+            _guard: self.state.start_write(location!()),
             ptr: self.data.get(),
         }
     }

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -45,7 +45,7 @@ impl Scheduler {
     where
         F: FnOnce(&mut Execution) -> R,
     {
-        Self::with_state(|state| f(&mut state.execution))
+        Self::with_state(|state| f(state.execution))
     }
 
     /// Perform a context switch


### PR DESCRIPTION
It looks like rustc 1.57.0 got slightly better at finding unused struct
fields and started emitting warnings for fields that are never read. In
all the cases that emitted a warning in loom, the unused field is a drop
guard which is held to indicate the lifetime of something, and is never
read from.

I've added leading `_`s to these fields' names to suppress the warnings.
This should fix the build.

Additionally, I fixed a clippy "needless borrow" warning.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>