### PR TITLE
chore: prepare to release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.5.4 (December 3, 2021)
+
+### Added
+
+- cell: Add `ConstPtr` and `MutPtr` RAII guards to `UnsafeCell` (#219)
+
+### Changed
+
+- Improve error message when execution state is unavailable (such as when
+  running outside of `loom::model`) (#242)
+  
 # 0.5.3 (November 23, 2021)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "loom"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]


### PR DESCRIPTION
# 0.5.4 (December 3, 2021)

### Added

- cell: Add `ConstPtr` and `MutPtr` RAII guards to `UnsafeCell` (#219)

### Changed

- Improve error message when execution state is unavailable (such as
  when running outside of `loom::model`) (#242)