### PR TITLE
fix double panic when exceeding the branch limit in `Drop`

### DIFF
--- a/src/rt/path.rs
+++ b/src/rt/path.rs
@@ -93,7 +93,7 @@ macro_rules! assert_path_len {
     ($branches:expr) => {{
         assert!(
             $branches.len() < $branches.capacity(),
-            "Model exeeded maximum number of branches. This is often caused \
+            "Model exceeded maximum number of branches. This is often caused \
              by an algorithm requiring the processor to make progress, e.g. \
              spin locks.",
         );

--- a/tests/double_panic_in_drop.rs
+++ b/tests/double_panic_in_drop.rs
@@ -1,0 +1,13 @@
+#[test]
+#[should_panic]
+fn double_panic_at_branch_max() {
+    let mut builder = loom::model::Builder::new();
+    builder.max_branches = 2;
+
+    builder.check(|| {
+        let _arc = loom::sync::Arc::new(());
+        loom::thread::yield_now();
+        loom::thread::yield_now();
+        loom::thread::yield_now();
+    });
+}


### PR DESCRIPTION
Loom will panic if the maximum number of branches is exceeded. If a
type's `Drop` impl performs a branch (for example, a `MutexGuard` or
`Arc`, or a user-defined type that performs atomic operations in its
`Drop` impl), we will hit the assertion a _second_ time, resulting in a
double panic. This sucks, because it makes these test failures much
harder to debug.

This branch fixes the issue by changing the assertion checking path
length to also check if the current thread is panicking. If we're
already panicking, we don't make the assertion, to avoid causing a
double panic. I've added a test that reproduces this double panic, as
well.

I've also fixed a typo in the assertion message. :)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>