### PR TITLE
Allow using `{Mut,Const}Ptr::{deref,with}` when the pointee is `!Sized`

### DIFF
--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -209,7 +209,7 @@ impl<T> From<T> for UnsafeCell<T> {
     }
 }
 
-impl<T> ConstPtr<T> {
+impl<T: ?Sized> ConstPtr<T> {
     /// Dereference the raw pointer.
     ///
     /// # Safety
@@ -377,7 +377,7 @@ impl<T> ConstPtr<T> {
     }
 }
 
-impl<T> MutPtr<T> {
+impl<T: ?Sized> MutPtr<T> {
     /// Dereference the raw pointer.
     ///
     /// # Safety


### PR DESCRIPTION
`?Sized` is easy to forget :P