### PR TITLE
thread: fix semantics of `thread::park` after `Thread::unpark`

### DIFF
--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -67,7 +67,7 @@ impl Id {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum State {
-    Runnable,
+    Runnable { unparked: bool },
     Blocked,
     Yield,
     Terminated,
@@ -84,7 +84,7 @@ impl Thread {
     fn new(id: Id) -> Thread {
         Thread {
             id,
-            state: State::Runnable,
+            state: State::Runnable { unparked: false },
             critical: false,
             operation: None,
             causality: VersionVec::new(),
@@ -97,11 +97,11 @@ impl Thread {
     }
 
     pub(crate) fn is_runnable(&self) -> bool {
-        matches!(self.state, State::Runnable)
+        matches!(self.state, State::Runnable { .. })
     }
 
     pub(crate) fn set_runnable(&mut self) {
-        self.state = State::Runnable;
+        self.state = State::Runnable { unparked: false };
     }
 
     pub(crate) fn set_blocked(&mut self) {
@@ -143,9 +143,16 @@ impl Thread {
 
     pub(crate) fn unpark(&mut self, unparker: &Thread) {
         self.causality.join(&unparker.causality);
+        self.set_unparked();
+    }
 
+    /// Unpark a thread's state. If it is already runnable, store the unpark for
+    /// a future call to `park`.
+    fn set_unparked(&mut self) {
         if self.is_blocked() || self.is_yield() {
             self.set_runnable();
+        } else if self.is_runnable() {
+            self.state = State::Runnable { unparked: true }
         }
     }
 }
@@ -257,6 +264,10 @@ impl Set {
 
     pub(crate) fn unpark(&mut self, id: Id) {
         if id == self.active_id() {
+            // The thread is unparking itself. We don't have to join its
+            // causality with the unparker's causality in this case, since the
+            // thread *is* the unparker. Just unpark its state.
+            self.active_mut().set_unparked();
             return;
         }
 

--- a/tests/thread_api.rs
+++ b/tests/thread_api.rs
@@ -103,3 +103,23 @@ fn thread_names() {
         let _ = th.join();
     })
 }
+
+#[test]
+fn park_unpark_loom() {
+    loom::model(|| {
+        println!("unpark");
+        thread::current().unpark();
+        println!("park");
+        thread::park();
+        println!("it did not deadlock");
+    });
+}
+
+#[test]
+fn park_unpark_std() {
+    println!("unpark");
+    std::thread::current().unpark();
+    println!("park");
+    std::thread::park();
+    println!("it did not deadlock");
+}


### PR DESCRIPTION
## Motivation

If `std::thread::Thread::unpark` is called _prior_ to a call to
`std::thread::park`, the `park` call will return immediately,
"consuming" the previous unpark. Per [the documentation][1]:

> The `unpark` method on a `Thread` atomically makes the token available
> if it wasn’t already. Because the token is initially absent, `unpark`
> followed by `park` will result in the second call returning
> immediately.

Loom's version of this API does not have this behavior. It appears that
`unpark` only notifies a thread if it is currently `park`ed, and does
not influence the next call to `park`.

The following test demonstrates this:

```rust
#[test]
fn park_unpark_loom() {
    loom::model(|| {
        loom::thread::current().unpark();
        loom::thread::park();
        println!("it did not deadlock");
    });
}

#[test]
fn park_unpark_std() {
    std::thread::current().unpark();
    std::thread::park();
    println!("it did not deadlock");
}
```

The `park_unpark_std` test will run to completion and print "it did not
deadlock", while the `park_unpark_loom` test panics with a deadlock
detection error:

```
running 2 tests
test park_unpark_std ... ok
test park_unpark_loom ... FAILED

failures:

---- park_unpark_loom stdout ----
unpark
park
thread 'park_unpark_loom' panicked at 'deadlock; threads = [(Id(0), Blocked)]', src/rt/execution.rs:209:13
stack backtrace:
   ...
```

See issue #246.

## Solution

This branch fixes the semantics of `loom::thread::Thread::unpark` to
match the behavior of the standard library. This is done by adding a
boolean to `rt::thread::State::Runnable` to track whether a thread was
unparked while it was runnable. When unparking a runnable thread, the
boolean is set; when parking, we check if the boolean is set, and unset
it, rather than actually setting the state to blocked.

This means that `unpark` followed by `park` should now behave the same
as `std::thread`.

Additionally, it was necessary to change `rt::thread::Set::unpark` a
little bit to handle threads unparking themselves. In the current
implementation, if a thread calls `unpark` on itself, nothing happens.
Now, though, we still have to update the thread's state to store the
unparking.

Fixes #246

[1]: https://doc.rust-lang.org/std/thread/fn.park.html#park-and-unpark