### PR TITLE
Add note about in-memory representation of atomic types

### DIFF
--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -3,6 +3,9 @@ use super::Atomic;
 use std::sync::atomic::Ordering;
 
 /// Mock implementation of `std::sync::atomic::AtomicBool`.
+///
+/// NOTE: Unlike `std::sync::atomic::AtomicBool`, this type has a different
+/// in-memory representation than `bool`.
 #[derive(Debug)]
 pub struct AtomicBool(Atomic<bool>);
 

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -10,10 +10,16 @@ macro_rules! doc_comment {
     };
 }
 
+#[rustfmt::skip] // rustfmt cannot properly format multi-line concat!.
 macro_rules! atomic_int {
     ($name: ident, $atomic_type: ty) => {
         doc_comment! {
-            concat!(" Mock implementation of `std::sync::atomic::", stringify!($name), "`."),
+            concat!(
+                " Mock implementation of `std::sync::atomic::", stringify!($name), "`.\n\n\
+                 NOTE: Unlike `std::sync::atomic::", stringify!($name), "`, \
+                 this type has a different in-memory representation than `",
+                 stringify!($atomic_type), "`.",
+            ),
             #[derive(Debug)]
             pub struct $name(Atomic<$atomic_type>);
         }

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -3,6 +3,9 @@ use super::Atomic;
 use std::sync::atomic::Ordering;
 
 /// Mock implementation of `std::sync::atomic::AtomicPtr`.
+///
+/// NOTE: Unlike `std::sync::atomic::AtomicPtr`, this type has a different
+/// in-memory representation than `*mut T`.
 #[derive(Debug)]
 pub struct AtomicPtr<T>(Atomic<*mut T>);
 


### PR DESCRIPTION
std's atomic types have the same in-memory representation as the underlying type.

https://doc.rust-lang.org/nightly/core/sync/atomic/struct.AtomicUsize.html

> This type has the same in-memory representation as the underlying integer type, usize.

loom's atomic types have a different in-memory representation than the underlying type. ([it](https://github.com/tokio-rs/loom/blob/3ebe3d1ee16b1c5f09ee3d46a3a621ebee04d6f0/src/rt/atomic.rs#L72-L73) is an [index](https://github.com/tokio-rs/loom/blob/3ebe3d1ee16b1c5f09ee3d46a3a621ebee04d6f0/src/rt/object.rs#L39-L41) in the store)
