### PR TITLE
Change derive(Debug) AtomicPtr to an explicit impl for all T, not just T: Derive.

### DIFF
--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -6,8 +6,13 @@ use std::sync::atomic::Ordering;
 ///
 /// NOTE: Unlike `std::sync::atomic::AtomicPtr`, this type has a different
 /// in-memory representation than `*mut T`.
-#[derive(Debug)]
 pub struct AtomicPtr<T>(Atomic<*mut T>);
+
+impl<T> std::fmt::Debug for AtomicPtr<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl<T> AtomicPtr<T> {
     /// Creates a new instance of `AtomicPtr`.


### PR DESCRIPTION
I think the root issue here is one of that tasks related to [rust#26925](https://github.com/rust-lang/rust/issues/26925). `AtomicPtr<T>` can still have a debug implementation for when `T` is not itself `Debug`.

This was brought up from doing work on [haphazard#32](https://github.com/jonhoo/haphazard/pull/32).