### PR TITLE
track locations

### DIFF
--- a/src/future/atomic_waker.rs
+++ b/src/future/atomic_waker.rs
@@ -21,8 +21,9 @@ impl AtomicWaker {
     }
 
     /// Registers the current task to be notified on calls to `wake`.
+    #[track_caller]
     pub fn register(&self, waker: Waker) {
-        if dbg!(!self.object.try_acquire_lock()) {
+        if dbg!(!self.object.try_acquire_lock(location!())) {
             waker.wake();
             // yield the task and try again... this is a spin lock.
             thread::yield_now();
@@ -47,8 +48,9 @@ impl AtomicWaker {
 
     /// Attempts to take the `Waker` value out of the `AtomicWaker` with the
     /// intention that the caller will wake the task later.
+    #[track_caller]
     pub fn take_waker(&self) -> Option<Waker> {
-        dbg!(self.object.acquire_lock());
+        dbg!(self.object.acquire_lock(location!()));
 
         let ret = self.waker.lock().unwrap().take();
 

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -13,6 +13,7 @@ use std::mem;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 /// Block the current thread, driving `f` to completion.
+#[track_caller]
 pub fn block_on<F>(f: F) -> F::Output
 where
     F: Future,
@@ -36,7 +37,7 @@ where
             Poll::Pending => {}
         }
 
-        notify.wait();
+        notify.wait(location!());
     }
 }
 
@@ -63,13 +64,13 @@ unsafe fn clone_arc_raw(data: *const ()) -> RawWaker {
 
 unsafe fn wake_arc_raw(data: *const ()) {
     let notify: Arc<rt::Notify> = Arc::from_raw(data as *const _);
-    notify.notify();
+    notify.notify(location!());
 }
 
 unsafe fn wake_by_ref_arc_raw(data: *const ()) {
     // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
     let arc = mem::ManuallyDrop::new(Arc::<rt::Notify>::from_raw(data as *const _));
-    arc.notify();
+    arc.notify(location!());
 }
 
 unsafe fn drop_arc_raw(data: *const ()) {

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -62,8 +62,8 @@ impl Arc {
         })
     }
 
-    pub(crate) fn ref_inc(&self) {
-        self.branch(Action::RefInc);
+    pub(crate) fn ref_inc(&self, location: Location) {
+        self.branch(Action::RefInc, location);
 
         rt::execution(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -74,8 +74,8 @@ impl Arc {
     }
 
     /// Validate a `get_mut` call
-    pub(crate) fn get_mut(&self) -> bool {
-        self.branch(Action::RefDec);
+    pub(crate) fn get_mut(&self, location: Location) -> bool {
+        self.branch(Action::RefDec, location);
 
         rt::execution(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -94,8 +94,8 @@ impl Arc {
     }
 
     /// Returns true if the memory should be dropped.
-    pub(crate) fn ref_dec(&self) -> bool {
-        self.branch(Action::RefDec);
+    pub(crate) fn ref_dec(&self, location: Location) -> bool {
+        self.branch(Action::RefDec, location);
 
         rt::execution(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -125,9 +125,9 @@ impl Arc {
         })
     }
 
-    fn branch(&self, action: Action) {
+    fn branch(&self, action: Action, location: Location) {
         let r = self.state;
-        r.branch_action(action);
+        r.branch_action(action, location);
         assert!(
             r.ref_eq(self.state),
             "Internal state mutated during branch. This is \

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -226,7 +226,7 @@ impl<T: Numeric> Atomic<T> {
 
     /// Loads a value from the atomic cell.
     pub(crate) fn load(&self, location: Location, ordering: Ordering) -> T {
-        self.branch(Action::Load);
+        self.branch(Action::Load, location);
 
         super::synchronize(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -271,7 +271,7 @@ impl<T: Numeric> Atomic<T> {
 
     /// Stores a value into the atomic cell.
     pub(crate) fn store(&self, location: Location, val: T, ordering: Ordering) {
-        self.branch(Action::Store);
+        self.branch(Action::Store, location);
 
         super::synchronize(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -304,7 +304,7 @@ impl<T: Numeric> Atomic<T> {
     where
         F: FnOnce(T) -> Result<T, E>,
     {
-        self.branch(Action::Rmw);
+        self.branch(Action::Rmw, location);
 
         super::synchronize(|execution| {
             let state = self.state.get_mut(&mut execution.objects);
@@ -384,9 +384,9 @@ impl<T: Numeric> Atomic<T> {
         f(&mut reset.0)
     }
 
-    fn branch(&self, action: Action) {
+    fn branch(&self, action: Action, location: Location) {
         let r = self.state;
-        r.branch_action(action);
+        r.branch_action(action, location);
         assert!(
             r.ref_eq(self.state),
             "Internal state mutated during branch. This is \

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -81,7 +81,7 @@ where
 }
 
 /// Marks the current thread as blocked
-pub fn park() {
+pub(crate) fn park(location: Location) {
     let switch = execution(|execution| {
         use thread::State;
         let thread = execution.threads.active_id();
@@ -97,10 +97,10 @@ pub fn park() {
                 return false;
             }
             // The thread doesn't have a saved unpark; set its state to blocked.
-            _ => active.set_blocked(),
+            _ => active.set_blocked(location),
         };
 
-        execution.threads.active_mut().set_blocked();
+        execution.threads.active_mut().set_blocked(location);
         execution.threads.active_mut().operation = None;
         execution.schedule()
     });

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -1,5 +1,5 @@
 use crate::rt::object;
-use crate::rt::{thread, Access, Synchronize, VersionVec};
+use crate::rt::{thread, Access, Location, Synchronize, VersionVec};
 
 use std::sync::atomic::Ordering::{Acquire, Release};
 
@@ -41,13 +41,13 @@ impl Mutex {
         })
     }
 
-    pub(crate) fn acquire_lock(&self) {
-        self.state.branch_acquire(self.is_locked());
+    pub(crate) fn acquire_lock(&self, location: Location) {
+        self.state.branch_acquire(self.is_locked(), location);
         assert!(self.post_acquire(), "expected to be able to acquire lock");
     }
 
-    pub(crate) fn try_acquire_lock(&self) -> bool {
-        self.state.branch_opaque();
+    pub(crate) fn try_acquire_lock(&self, location: Location) -> bool {
+        self.state.branch_opaque(location);
         self.post_acquire()
     }
 
@@ -118,15 +118,13 @@ impl Mutex {
                     continue;
                 }
 
-                let obj = thread
-                    .operation
-                    .as_ref()
-                    .map(|operation| operation.object());
-
-                if obj == Some(self.state.erase()) {
-                    trace!(state = ?self.state, thread = ?id,
-                           "Mutex::post_acquire");
-                    thread.set_blocked();
+                if let Some(operation) = thread.operation.as_ref() {
+                    if operation.object() == self.state.erase() {
+                        let location = operation.location();
+                        trace!(state = ?self.state, thread = ?id,
+                            "Mutex::post_acquire");
+                        thread.set_blocked(location);
+                    }
                 }
             }
 

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -1,5 +1,5 @@
 use crate::rt;
-use crate::rt::{Access, Execution, VersionVec};
+use crate::rt::{Access, Execution, Location, VersionVec};
 
 use std::fmt;
 use std::marker::PhantomData;
@@ -48,6 +48,7 @@ pub(super) struct Ref<T = ()> {
 pub(super) struct Operation {
     obj: Ref,
     action: Action,
+    location: Location,
 }
 
 // TODO: move to separate file
@@ -329,45 +330,54 @@ impl<T> fmt::Debug for Ref<T> {
 // TODO: These fns shouldn't be on Ref
 impl<T: Object<Entry = Entry>> Ref<T> {
     // TODO: rename `branch_disable`
-    pub(super) fn branch_acquire(self, is_locked: bool) {
+    pub(super) fn branch_acquire(self, is_locked: bool, location: Location) {
         super::branch(|execution| {
             trace!(obj = ?self, ?is_locked, "Object::branch_acquire");
 
-            self.set_action(execution, Action::Opaque);
+            self.set_action(execution, Action::Opaque, location);
 
             if is_locked {
                 // The mutex is currently blocked, cannot make progress
-                execution.threads.active_mut().set_blocked();
+                execution.threads.active_mut().set_blocked(location);
             }
         })
     }
 
-    pub(super) fn branch_action(self, action: impl Into<Action> + std::fmt::Debug) {
+    pub(super) fn branch_action(
+        self,
+        action: impl Into<Action> + std::fmt::Debug,
+        location: Location,
+    ) {
         super::branch(|execution| {
             trace!(obj = ?self, ?action, "Object::branch_action");
 
-            self.set_action(execution, action.into());
+            self.set_action(execution, action.into(), location);
         })
     }
 
-    pub(super) fn branch_disable(self, action: impl Into<Action> + std::fmt::Debug, disable: bool) {
+    pub(super) fn branch_disable(
+        self,
+        action: impl Into<Action> + std::fmt::Debug,
+        disable: bool,
+        location: Location,
+    ) {
         super::branch(|execution| {
             trace!(obj = ?self, ?action, ?disable, "Object::branch_disable");
 
-            self.set_action(execution, action.into());
+            self.set_action(execution, action.into(), location);
 
             if disable {
                 // Cannot make progress.
-                execution.threads.active_mut().set_blocked();
+                execution.threads.active_mut().set_blocked(location);
             }
         })
     }
 
-    pub(super) fn branch_opaque(self) {
-        self.branch_action(Action::Opaque)
+    pub(super) fn branch_opaque(self, location: Location) {
+        self.branch_action(Action::Opaque, location)
     }
 
-    fn set_action(self, execution: &mut Execution, action: Action) {
+    fn set_action(self, execution: &mut Execution, action: Action, location: Location) {
         assert!(
             T::get_ref(&execution.objects.entries[self.index]).is_some(),
             "failed to get object for ref {:?}",
@@ -377,6 +387,7 @@ impl<T: Object<Entry = Entry>> Ref<T> {
         execution.threads.active_mut().operation = Some(Operation {
             obj: self.erase(),
             action,
+            location,
         });
     }
 }
@@ -385,8 +396,13 @@ impl Operation {
     pub(super) fn object(&self) -> Ref {
         self.obj
     }
+
     pub(super) fn action(&self) -> Action {
         self.action
+    }
+
+    pub(super) fn location(&self) -> Location {
+        self.location
     }
 }
 

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -3,6 +3,8 @@ use crate::rt::object::Operation;
 use crate::rt::vv::VersionVec;
 
 use std::{any::Any, collections::HashMap, fmt, ops};
+
+use super::Location;
 pub(crate) struct Thread {
     pub id: Id,
 
@@ -68,7 +70,7 @@ impl Id {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum State {
     Runnable { unparked: bool },
-    Blocked,
+    Blocked(Location),
     Yield,
     Terminated,
 }
@@ -104,12 +106,12 @@ impl Thread {
         self.state = State::Runnable { unparked: false };
     }
 
-    pub(crate) fn set_blocked(&mut self) {
-        self.state = State::Blocked;
+    pub(crate) fn set_blocked(&mut self, location: Location) {
+        self.state = State::Blocked(location);
     }
 
     pub(crate) fn is_blocked(&self) -> bool {
-        matches!(self.state, State::Blocked)
+        matches!(self.state, State::Blocked(..))
     }
 
     pub(crate) fn is_yield(&self) -> bool {

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -72,8 +72,9 @@ impl<T> Arc<T> {
 
     /// Returns a mutable reference to the inner value, if there are
     /// no other `Arc` pointers to the same value.
+    #[track_caller]
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
-        if this.inner.obj.get_mut() {
+        if this.inner.obj.get_mut(location!()) {
             assert_eq!(1, std::sync::Arc::strong_count(&this.inner));
             Some(&mut std::sync::Arc::get_mut(&mut this.inner).unwrap().value)
         } else {
@@ -140,7 +141,7 @@ impl<T> ops::Deref for Arc<T> {
 
 impl<T> Clone for Arc<T> {
     fn clone(&self) -> Arc<T> {
-        self.inner.obj.ref_inc();
+        self.inner.obj.ref_inc(location!());
 
         Arc {
             inner: self.inner.clone(),
@@ -150,7 +151,7 @@ impl<T> Clone for Arc<T> {
 
 impl<T> Drop for Arc<T> {
     fn drop(&mut self) {
-        if self.inner.obj.ref_dec() {
+        if self.inner.obj.ref_dec(location!()) {
             assert_eq!(
                 1,
                 std::sync::Arc::strong_count(&self.inner),

--- a/src/sync/condvar.rs
+++ b/src/sync/condvar.rs
@@ -24,13 +24,14 @@ impl Condvar {
     }
 
     /// Blocks the current thread until this condition variable receives a notification.
+    #[track_caller]
     pub fn wait<'a, T>(&self, mut guard: MutexGuard<'a, T>) -> LockResult<MutexGuard<'a, T>> {
         // Release the RefCell borrow guard allowing another thread to lock the
         // data
         guard.unborrow();
 
         // Wait until notified
-        self.object.wait(guard.rt());
+        self.object.wait(guard.rt(), location!());
 
         // Borrow the mutex guarded data again
         guard.reborrow();
@@ -52,13 +53,15 @@ impl Condvar {
     }
 
     /// Wakes up one blocked thread on this condvar.
+    #[track_caller]
     pub fn notify_one(&self) {
-        self.object.notify_one();
+        self.object.notify_one(location!());
     }
 
     /// Wakes up all blocked threads on this condvar.
+    #[track_caller]
     pub fn notify_all(&self) {
-        self.object.notify_all();
+        self.object.notify_all(location!());
     }
 }
 

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -27,8 +27,9 @@ pub struct Sender<T> {
 impl<T> Sender<T> {
     /// Attempts to send a value on this channel, returning it back if it could
     /// not be sent.
+    #[track_caller]
     pub fn send(&self, msg: T) -> Result<(), std::sync::mpsc::SendError<T>> {
-        self.object.send();
+        self.object.send(location!());
         self.sender.send(msg)
     }
 }
@@ -52,8 +53,9 @@ pub struct Receiver<T> {
 impl<T> Receiver<T> {
     /// Attempts to wait for a value on this receiver, returning an error if the
     /// corresponding channel has hung up.
+    #[track_caller]
     pub fn recv(&self) -> Result<T, std::sync::mpsc::RecvError> {
-        self.object.recv();
+        self.object.recv(location!());
         self.receiver.recv()
     }
     /// Attempts to wait for a value on this receiver, returning an error if the

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -29,8 +29,9 @@ impl<T> Mutex<T> {
 
 impl<T> Mutex<T> {
     /// Acquires a mutex, blocking the current thread until it is able to do so.
+    #[track_caller]
     pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
-        self.object.acquire_lock();
+        self.object.acquire_lock(location!());
 
         Ok(MutexGuard {
             lock: self,
@@ -45,8 +46,9 @@ impl<T> Mutex<T> {
     /// guard is dropped.
     ///
     /// This function does not block.
+    #[track_caller]
     pub fn try_lock(&self) -> TryLockResult<MutexGuard<'_, T>> {
-        if self.object.try_acquire_lock() {
+        if self.object.try_acquire_lock(location!()) {
             Ok(MutexGuard {
                 lock: self,
                 data: Some(self.data.lock().unwrap()),

--- a/src/sync/notify.rs
+++ b/src/sync/notify.rs
@@ -27,17 +27,19 @@ impl Notify {
     }
 
     /// Notify the waiter
+    #[track_caller]
     pub fn notify(&self) {
-        self.object.notify();
+        self.object.notify(location!());
     }
 
     /// Wait for a notification
+    #[track_caller]
     pub fn wait(&self) {
         self.waiting
             .compare_exchange(false, true, SeqCst, SeqCst)
             .expect("only a single thread may wait on `Notify`");
 
-        self.object.wait();
+        self.object.wait(location!());
         self.waiting.store(false, SeqCst);
     }
 }

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -43,8 +43,9 @@ impl<T> RwLock<T> {
     /// lock when this method returns. This method does not provide any
     /// guarantees with respect to the ordering of whether contentious readers
     /// or writers will acquire the lock first.
+    #[track_caller]
     pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
-        self.object.acquire_read_lock();
+        self.object.acquire_read_lock(location!());
 
         Ok(RwLockReadGuard {
             lock: self,
@@ -59,8 +60,9 @@ impl<T> RwLock<T> {
     /// access when it is dropped.
     ///
     /// This function does not block.
+    #[track_caller]
     pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<'_, T>> {
-        if self.object.try_acquire_read_lock() {
+        if self.object.try_acquire_read_lock(location!()) {
             Ok(RwLockReadGuard {
                 lock: self,
                 data: Some(self.data.try_read().expect("loom::RwLock state corrupt")),
@@ -75,8 +77,9 @@ impl<T> RwLock<T> {
     ///
     /// This function will not return while other writers or other readers
     /// currently have access to the lock.
+    #[track_caller]
     pub fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
-        self.object.acquire_write_lock();
+        self.object.acquire_write_lock(location!());
 
         Ok(RwLockWriteGuard {
             lock: self,
@@ -91,8 +94,9 @@ impl<T> RwLock<T> {
     /// it is dropped.
     ///
     /// This function does not block.
+    #[track_caller]
     pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<'_, T>> {
-        if self.object.try_acquire_write_lock() {
+        if self.object.try_acquire_write_lock(location!()) {
             Ok(RwLockWriteGuard {
                 lock: self,
                 data: Some(self.data.try_write().expect("loom::RwLock state corrupt")),


### PR DESCRIPTION
This PR is mostly just mechanical. It adds `#[track_caller]` and gets the location in the public API and plumbs it through. This helps debug deadlocks:

```
thread 'runtime::tests::loom_pool::group_a::pool_multi_spawn' panicked at 'deadlock; threads = [(Id(0), Blocked(Location(Some(Location { file: "tokio/src/runtime/tests/loom_oneshot.rs", line: 45, col: 31 })))), (Id(1), Blocked(Location(Some(Location { file: "tokio/src/park/thread.rs", line: 112, col: 30 })))), (Id(2), Blocked(Location(Some(Location { file: "tokio/src/runtime/thread_pool/park.rs", line: 206, col: 30 }))))]'
```

The output is pretty bad, but it is definitely helpful :)