### PR TITLE
add additional location tracking to `Arc`, `alloc`, and `mpsc`

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -19,9 +19,10 @@ pub use std::alloc::Layout;
 /// See [`GlobalAlloc::alloc`].
 ///
 /// [`GlobalAlloc::alloc`]: std::alloc::GlobalAlloc::alloc
+#[track_caller]
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     let ptr = std::alloc::alloc(layout);
-    rt::alloc(ptr);
+    rt::alloc(ptr, location!());
     ptr
 }
 
@@ -40,9 +41,10 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 /// See [`GlobalAlloc::alloc_zeroed`].
 ///
 /// [`GlobalAlloc::alloc_zeroed`]: std::alloc::GlobalAlloc::alloc_zeroed
+#[track_caller]
 pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
     let ptr = std::alloc::alloc_zeroed(layout);
-    rt::alloc(ptr);
+    rt::alloc(ptr, location!());
     ptr
 }
 
@@ -63,8 +65,9 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 /// See [`GlobalAlloc::dealloc`].
 ///
 /// [`GlobalAlloc::dealloc`]: std::alloc::GlobalAlloc::dealloc
+#[track_caller]
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
-    rt::dealloc(ptr);
+    rt::dealloc(ptr, location!());
     std::alloc::dealloc(ptr, layout)
 }
 
@@ -78,10 +81,11 @@ pub struct Track<T> {
 
 impl<T> Track<T> {
     /// Track a value for leaks
+    #[track_caller]
     pub fn new(value: T) -> Track<T> {
         Track {
             value,
-            _obj: rt::Allocation::new(),
+            _obj: rt::Allocation::new(location!()),
         }
     }
 

--- a/src/rt/alloc.rs
+++ b/src/rt/alloc.rs
@@ -1,5 +1,5 @@
 use crate::rt;
-use crate::rt::object;
+use crate::rt::{object, Location};
 
 use tracing::trace;
 
@@ -12,16 +12,20 @@ pub(crate) struct Allocation {
 #[derive(Debug)]
 pub(super) struct State {
     is_dropped: bool,
+    allocated: Location,
 }
 
 /// Track a raw allocation
-pub(crate) fn alloc(ptr: *mut u8) {
+pub(crate) fn alloc(ptr: *mut u8, location: Location) {
     rt::execution(|execution| {
-        let state = execution.objects.insert(State { is_dropped: false });
+        let state = execution.objects.insert(State {
+            is_dropped: false,
+            allocated: location,
+        });
 
         let allocation = Allocation { state };
 
-        trace!(?allocation.state, ?ptr, "alloc");
+        trace!(?allocation.state, ?ptr, %location, "alloc");
 
         let prev = execution.raw_allocations.insert(ptr as usize, allocation);
         assert!(prev.is_none(), "pointer already tracked");
@@ -29,12 +33,12 @@ pub(crate) fn alloc(ptr: *mut u8) {
 }
 
 /// Track a raw deallocation
-pub(crate) fn dealloc(ptr: *mut u8) {
+pub(crate) fn dealloc(ptr: *mut u8, location: Location) {
     let allocation =
         rt::execution(
             |execution| match execution.raw_allocations.remove(&(ptr as usize)) {
                 Some(allocation) => {
-                    trace!(state = ?allocation.state, ?ptr, "dealloc");
+                    trace!(state = ?allocation.state, ?ptr, %location, "dealloc");
 
                     allocation
                 }
@@ -47,11 +51,14 @@ pub(crate) fn dealloc(ptr: *mut u8) {
 }
 
 impl Allocation {
-    pub(crate) fn new() -> Allocation {
+    pub(crate) fn new(location: Location) -> Allocation {
         rt::execution(|execution| {
-            let state = execution.objects.insert(State { is_dropped: false });
+            let state = execution.objects.insert(State {
+                is_dropped: false,
+                allocated: location,
+            });
 
-            trace!(?state, "Allocation::new");
+            trace!(?state, %location, "Allocation::new");
 
             Allocation { state }
         })
@@ -59,11 +66,13 @@ impl Allocation {
 }
 
 impl Drop for Allocation {
+    #[track_caller]
     fn drop(&mut self) {
+        let location = location!();
         rt::execution(|execution| {
-            trace!(state = ?self.state, "Allocation::drop");
-
             let state = self.state.get_mut(&mut execution.objects);
+
+            trace!(state = ?self.state, drop.location = %location, "Allocation::drop");
 
             state.is_dropped = true;
         });
@@ -71,7 +80,16 @@ impl Drop for Allocation {
 }
 
 impl State {
-    pub(super) fn check_for_leaks(&self) {
-        assert!(self.is_dropped, "object leaked");
+    pub(super) fn check_for_leaks(&self, index: usize) {
+        if !self.is_dropped {
+            if self.allocated.is_captured() {
+                panic!(
+                    "Allocation leaked.\n  Allocated: {}\n      Index: {}",
+                    self.allocated, index
+                );
+            } else {
+                panic!("Allocation leaked.\n  Index: {}", index);
+            }
+        }
     }
 }

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -138,12 +138,15 @@ impl Arc {
 }
 
 impl State {
-    pub(super) fn check_for_leaks(&self) {
+    pub(super) fn check_for_leaks(&self, index: usize) {
         if self.ref_cnt != 0 {
             if self.allocated.is_captured() {
-                panic!("Arc leaked.\n  Allocated: {}", self.allocated);
+                panic!(
+                    "Arc leaked.\n  Allocated: {}\n      Index: {}",
+                    self.allocated, index
+                );
             } else {
-                panic!("Arc leaked.");
+                panic!("Arc leaked.\n  Index: {}", index);
             }
         }
     }

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -69,7 +69,7 @@ impl Arc {
             let state = self.state.get_mut(&mut execution.objects);
             state.ref_cnt = state.ref_cnt.checked_add(1).expect("overflow");
 
-            trace!(state = ?self.state, ref_cnt = ?state.ref_cnt, "Arc::ref_inc");
+            trace!(state = ?self.state, ref_cnt = ?state.ref_cnt, %location, "Arc::ref_inc");
         })
     }
 
@@ -87,7 +87,7 @@ impl Arc {
 
             let is_only_ref = state.ref_cnt == 1;
 
-            trace!(state = ?self.state, ?is_only_ref, "Arc::get_mut");
+            trace!(state = ?self.state, ?is_only_ref, %location, "Arc::get_mut");
 
             is_only_ref
         })
@@ -105,7 +105,7 @@ impl Arc {
             // Decrement the ref count
             state.ref_cnt -= 1;
 
-            trace!(state = ?self.state, ref_cnt = ?state.ref_cnt, "Arc::ref_dec");
+            trace!(state = ?self.state, ref_cnt = ?state.ref_cnt, %location, "Arc::ref_dec");
 
             // Synchronize the threads.
             state

--- a/src/rt/arc.rs
+++ b/src/rt/arc.rs
@@ -56,7 +56,7 @@ impl Arc {
                 last_ref_dec: None,
             });
 
-            trace!(?state, "Arc::new");
+            trace!(?state, %location, "Arc::new");
 
             Arc { state }
         })

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,3 +1,7 @@
+#[macro_use]
+mod location;
+pub(crate) use self::location::Location;
+
 mod access;
 use self::access::Access;
 
@@ -9,10 +13,6 @@ pub(crate) use self::arc::Arc;
 
 mod atomic;
 pub(crate) use self::atomic::{fence, Atomic};
-
-#[macro_use]
-mod location;
-pub(crate) use self::location::Location;
 
 pub(crate) mod cell;
 pub(crate) use self::cell::Cell;

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -252,7 +252,7 @@ impl Store {
             match entry {
                 Entry::Alloc(entry) => entry.check_for_leaks(index),
                 Entry::Arc(entry) => entry.check_for_leaks(index),
-                Entry::Channel(entry) => entry.check_for_leaks(),
+                Entry::Channel(entry) => entry.check_for_leaks(index),
                 _ => {}
             }
         }

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -250,7 +250,7 @@ impl Store {
     pub(crate) fn check_for_leaks(&self) {
         for (index, entry) in self.entries.iter().enumerate() {
             match entry {
-                Entry::Alloc(entry) => entry.check_for_leaks(),
+                Entry::Alloc(entry) => entry.check_for_leaks(index),
                 Entry::Arc(entry) => entry.check_for_leaks(index),
                 Entry::Channel(entry) => entry.check_for_leaks(),
                 _ => {}

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -248,10 +248,10 @@ impl Store {
 
     /// Panics if any leaks were detected
     pub(crate) fn check_for_leaks(&self) {
-        for entry in &self.entries[..] {
+        for (index, entry) in self.entries.iter().enumerate() {
             match entry {
                 Entry::Alloc(entry) => entry.check_for_leaks(),
-                Entry::Arc(entry) => entry.check_for_leaks(),
+                Entry::Arc(entry) => entry.check_for_leaks(index),
                 Entry::Channel(entry) => entry.check_for_leaks(),
                 _ => {}
             }

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -3,9 +3,11 @@
 use crate::rt;
 
 /// Mock implementation of `std::sync::mpsc::channel`.
+#[track_caller]
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let location = location!();
     let (sender_channel, receiver_channel) = std::sync::mpsc::channel();
-    let channel = std::sync::Arc::new(rt::Channel::new());
+    let channel = std::sync::Arc::new(rt::Channel::new(location));
     let sender = Sender {
         object: std::sync::Arc::clone(&channel),
         sender: sender_channel,


### PR DESCRIPTION
## Motivation

Currently, loom's mock `Arc` will track the source code location where
the `Arc` was created. This is useful for diagnosing problems, but it
isn't always *enough* to make the output easy to understand. 

In particular, `LOOM_LOG=trace` will indicate where the `Arc` was
created, and will log ref count operations on that `Arc`. The creation
location is useful , but ref count operations aren't associated with a
location --- so a user reading the log cannot determine _where_ the
`Arc`'s reference count was incremented or decremented from. This makes
tracking leaks difficult.

Additionally, in the `LOOM_LOG` output, each `Arc` instance is
identified by its `Ref` (an index in the store of loom object states).
This permits tracking an individual `Arc`'s refcount lifecycle in the
logs. However, when a leak is detected, the panic message does not
include this index, so it's not possible to determine which particular
`Arc` was leaked. The location where the `Arc` was created is included,
but multiple `Arc`s may have originated from the same location.

## Solution

This branch improves `Arc` debuggability by adding location tracking to
operations that increment and decrement the `Arc`'s reference count. It
also adds the index in the object store to the panic message when a leak
is detected, so the user can now go back and look for all the events for
the `Arc` instance with that ID. This should make debugging `Arc` leaks
much easier.

Similarly, I've also added location tracking to Loom's `alloc` and
`mpsc` mocks, and modified their panic messages to print the store index
as well. 