### PR TITLE
improve `LOOM_LOG` tracing

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -219,6 +219,8 @@ where
 {
     let subscriber = fmt::Subscriber::builder()
         .with_env_filter(EnvFilter::from_env("LOOM_LOG"))
+        .with_test_writer()
+        .without_time()
         .finish();
 
     subscriber::with_default(subscriber, || {


### PR DESCRIPTION
This branch makes a few minor improvements to how Loom uses `tracing` to
generate `LOOM_LOG` output:

* Added `with_test_writer` to the `tracing` subscriber. This allows logs
  written by Loom to be captured by `libtest`. This way, running Loom
  tests with `--show-output` will print the `LOOM_LOG` output from each
  test under that test's heading. Similarly, this allows libtest to
  capture Loom log output by default, and print the output back for
  failed tests.

* Updated to the latest `tracing-subscriber` version. This gets us
  slightly nicer-looking formatting but is otherwise not that important.

* Added `tracing` spans for each simulated Loom thread. Now, when we
  switch threads, we also switch to that thread's corresponding
  `tracing` span. This way, all output in the log is annotated with the
  current thread's name, which should help improve debuggability a bit.

* Added a `tracing` span with the model's current iteration. This should
  make it much easier to distinguish when a new iteration has started,
  while reading the logs.

## Examples

Current `master`. Note how the log output from all tests is mushed
together, and is not captured by `libtest`:
![image](https://user-images.githubusercontent.com/2796466/166804884-386834b8-dab4-440a-a89d-76a01cecd3f5.png)

This branch. Note how all `tracing` events are now annotated with
the thread ID and the current iteration, and how `libtest` is able to
capture output and separate it by which test emitted it:
![image](https://user-images.githubusercontent.com/2796466/166808812-57230671-2372-42b7-b004-bf0b10024b19.png)
