### PR TITLE
ci: automatically publish GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+# automatically publish GitHub releases for release tags
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    # only publish from the origin repository
+    if: github.repository_owner == 'tokio-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          title: "Loom $version"
+          branch: master
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, Loom publishes a GitHub release when publishing a new version
of the crate. However, this is an extra step in the release process which
is easy to accidentally forget: the current release is v0.5.4, but the
last GitHub release was v0.5.2.

This branch introduces automatic publishing of GitHub releases for
release tags, using taiki-e/create-gh-release-action. GitHub releases
are automatically created when a tag matching the regex `v[0-9]+.*` is
pushed to the `master` branch on the origin repository. The release
notes are automatically populated from CHANGELOG.md.

This should make it much easier to remember all the manual steps to
release a new version of loom --- we only need to push a tag, not push
a tag *and* create a release.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>