### PR TITLE
docs: fix broken rustdoc links

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -65,6 +65,8 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 /// See [`GlobalAlloc::dealloc`].
 ///
 /// [`GlobalAlloc::dealloc`]: std::alloc::GlobalAlloc::dealloc
+/// [`loom::alloc::alloc`]: crate::alloc::alloc
+/// [`loom::alloc::alloc_zeroed`]: crate::alloc::alloc_zeroed
 #[track_caller]
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
     rt::dealloc(ptr, location!());

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -37,7 +37,7 @@ impl Thread {
         self.name.as_deref()
     }
 
-    /// Mock implementation of [`std::thread::unpark`].
+    /// Mock implementation of [`std::thread::Thread::unpark`].
     ///
     /// Atomically makes the handle's token available if it is not already.
     ///


### PR DESCRIPTION
PR #151 added a CI job to try and build the documentation, failing on
RustDoc errors. It turned out there was a handful of broken links, so
that job is now failing. 

I meant to fix this as part of #151 but accidentally automerged it
before fixing the docs, since automerge wasn't configured to require the
docs build job to pass. Whoops.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>