### PR TITLE
Update actions/checkout action to v3 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'tokio-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md


### PR DESCRIPTION
Same as https://github.com/tokio-rs/loom/pull/264, but for release.yml that didn't exist when that PR was created.