### PR TITLE
Upgrade tracing subscriber and check minimum dependency versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,25 @@ jobs:
       - name: Check
         run: cargo check --all-features
 
+  # Minimal dependency versions
+  minimal-dependency-versions:
+    name: minimal dependency versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+      - name: Install nightly Rust
+        run: rustup update nightly
+      - name: Set all dependencies to lowest allowed versions
+        run: cargo +nightly update -Z minimal-versions
+      - name: Test
+        run: cargo test
+      - name: Check --features checkpoint
+        run: cargo check --features checkpoint
+      - name: Test --features futures
+        run: cargo test --features futures
+
   # Stable
   stable:
     name: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = { version = "1.0.33", optional = true }
 pin-utils = { version = "0.1.0", optional = true }
 
 tracing = "0.1.27"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.8", features = ["env-filter"] }
 
 [dev-dependencies]
 futures-util = "0.3.0"


### PR DESCRIPTION
Increase the minimum bound on the `tracing-subscriber` dependency in order to make `cargo +nightly update -Z minimal-versions && cargo check` work on this crate. See https://github.com/tokio-rs/tracing/pull/1890

I also added to CI to have it check the minimal versions. Do you like it this way? It's a bunch of duplication. But I felt it made sense to check the minimal versions with all the same tasks as the normal stable test.