### PR TITLE
Bump MSRV to 1.59

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.51.0 && rustup default 1.51.0
+        run: rustup update 1.59.0 && rustup default 1.59.0
       - name: Check
         run: cargo check --all-features
 


### PR DESCRIPTION
Since dependencies changed their MSRV in a minor update, loom currently depends on `scoped-tls 1.0.1`, which has MSRV 1.59, making the minrust job fail.