### PR TITLE
Fix drop order of tls and statics and avoid double panics on deadlock

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -1,4 +1,13 @@
 //! Mock implementation of the `lazy_static` crate.
+//!
+//! Note: unlike the [semantics] of the `lazy_static` crate, this
+//! mock implementation *will* drop its value when the program finishes.
+//! This is due to an implementation detail in `loom`: it will create
+//! many instances of the same program and this would otherwise lead
+//! to unbounded memory leaks due to instantiating the lazy static
+//! many times over.
+//!
+//! [semantics]: https://docs.rs/lazy_static/latest/lazy_static/#semantics
 
 use crate::rt;
 pub use crate::rt::thread::AccessError;
@@ -12,6 +21,15 @@ use std::fmt;
 use std::marker::PhantomData;
 
 /// Mock implementation of `lazy_static::Lazy`.
+///
+/// Note: unlike the [semantics] of the `lazy_static` crate, this
+/// mock implementation *will* drop its value when the program finishes.
+/// This is due to an implementation detail in `loom`: it will create
+/// many instances of the same program and this would otherwise lead
+/// to unbounded memory leaks due to instantiating the lazy static
+/// many times over.
+///
+/// [semantics]: https://docs.rs/lazy_static/latest/lazy_static/#semantics
 pub struct Lazy<T> {
     // Sadly, these fields have to be public, since function pointers in const
     // fns are unstable. When fn pointer arguments to const fns stabilize, these

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -207,13 +207,13 @@ impl Execution {
 
         self.threads.set_active(next);
 
-        // There is no active thread. Unless all threads have terminated, the
-        // test has deadlocked.
+        // There is no active thread. Unless all threads have terminated
+        // or the current thread is panicking, the test has deadlocked.
         if !self.threads.is_active() {
             let terminal = self.threads.iter().all(|(_, th)| th.is_terminated());
 
             assert!(
-                terminal,
+                terminal || std::thread::panicking(),
                 "deadlock; threads = {:?}",
                 self.threads
                     .iter()

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -73,8 +73,27 @@ where
     trace!(thread = ?id, "spawn");
 
     Scheduler::spawn(Box::new(move || {
+        /// the given closure `f` may panic when executed.
+        /// when this happens, we still want to ensure that
+        /// thread locals are destructed. therefore, we set
+        /// up a guard that is dropped as part of the unwind
+        /// logic when `f` panics.
+        struct PanicGuard;
+        impl Drop for PanicGuard {
+            fn drop(&mut self) {
+                thread_done(false);
+            }
+        }
+
+        // set up the panic guard
+        let panic_guard = PanicGuard;
+
+        // execute the closure, note that `f()` may panic!
         f();
-        thread_done(false);
+
+        // if `f()` didn't panic, then we terminate the
+        // spawned thread by dropping the guard ourselves.
+        drop(panic_guard);
     }));
 
     id
@@ -172,6 +191,21 @@ where
 }
 
 pub fn thread_done(is_main_thread: bool) {
+    let is_active = execution(|execution| execution.threads.is_active());
+    if !is_active {
+        // if the thread is not active and the current thread is panicking,
+        // then this means that loom has detected a problem (e.g. a deadlock).
+        // we don't want to throw a double panic here, because this would cause
+        // the entire test to abort and this hides the error from the end user.
+        // instead we ensure that the current thread is panicking already,
+        // or we cause a panic if it's not yet panicking (which it otherwise
+        // would anyway, on the call to `execution.threads.active_id()` below).
+        let panicking = std::thread::panicking();
+        trace!(?panicking, "thread_done: no active thread");
+        assert!(panicking);
+        return;
+    }
+
     let locals = execution(|execution| {
         let thread = execution.threads.active_id();
 

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -6,7 +6,7 @@ use loom::thread;
 use std::rc::Rc;
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "deadlock; threads =")]
 fn two_mutexes_deadlock() {
     loom::model(|| {
         let a = Rc::new(Mutex::new(1));


### PR DESCRIPTION
Hello! I ran into some of the same issues as mentioned in #152, #179 and #291 and developed a fix for all of those issues. In a nutshell, the changes are:

- clarify the documentation of the mock `lazy_static` implementation regarding its `Drop` implementation
- ensure that global statics are dropped after thread locals
- ensure that `loom` does not panic inside a panic when dropping thread locals on the main thread
- add two regression tests for #152
- ensure that thread locals are destructed when a spawned thread panics
- ensure that loom doesn't double panic on deadlock
- add a test to verify that thread locals are properly destructed on spawned threads
- sprinkle comments generously everywhere to explain the code changes

This is my first time contributing to `loom`, please let me know if I can somehow improve this PR or if additional information is needed. Thank you!