### PR TITLE
Fix for corner case where `RwLock` could be acquired in write mode while write locked

### DIFF
--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -230,7 +230,8 @@ impl RwLock {
             // Set the lock to the current thread
             state.lock = match state.lock {
                 Some(Locked::Read(_)) => return false,
-                _ => Some(Locked::Write(thread_id)),
+                Some(Locked::Write(_)) => return false,
+                None => Some(Locked::Write(thread_id)),
             };
 
             state.synchronize.sync_load(&mut execution.threads, Acquire);


### PR DESCRIPTION
This PR contains a minor 2 line fix for a corner case where a `RwLock` could erroneously be acquired in write mode while already being write locked. This led to a panic saying `loom::RwLock state corrupt: "WouldBlock"`, while it instead should return the `WouldBlock` error state on `RwLock::try_write` or (potentially) signal a deadlock when calling `RwLock::write`. I also took the liberty of adding some more test cases for `RwLock`, which will also detect any regressions of this bug.