### PR TITLE
Add assertion that picked thread is runnable

### DIFF
--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -202,6 +202,12 @@ impl Execution {
                 }
             })
         });
+        if let Some(next) = next {
+            assert!(
+                self.threads[next].is_runnable() || self.threads[next].is_yield(),
+                "Picked a thread for execution that is not actually runnable",
+            );
+        }
 
         let switched = Some(self.threads.active_id()) != next;
 


### PR DESCRIPTION
`Path::branch_thread` only picks threads the execution plan considers runnable. Thus, when this assertion fails, it is an indication that the model of execution paths diverged from the actual execution.

(I also push this to test if the CI failure in #304 is due to the new rust version)