### PR TITLE
Make thread stack size configurable

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -45,7 +45,7 @@ mod rwlock;
 pub(crate) use self::rwlock::RwLock;
 
 mod scheduler;
-pub(crate) use self::scheduler::Scheduler;
+pub(crate) use self::scheduler::{Scheduler, ScheduleParams};
 
 mod synchronize;
 pub(crate) use self::synchronize::Synchronize;

--- a/tests/thread_api.rs
+++ b/tests/thread_api.rs
@@ -123,3 +123,17 @@ fn park_unpark_std() {
     std::thread::park();
     println!("it did not deadlock");
 }
+
+#[test]
+fn max_stack_size() {
+    const LARGE_STACK_SIZE: usize = 0x8000;
+    let mut builder = loom::model::Builder::new();
+
+    builder.thread_stack_size = LARGE_STACK_SIZE;
+
+    builder.check(|| {
+        let mut large_array = [0u8; LARGE_STACK_SIZE];
+        // Ensure the array actually gets allocated on the stack.
+        std::hint::black_box(&mut large_array);
+    })
+}


### PR DESCRIPTION
The default value of 4096 bytes is too small for some code. Make the value configurable via the Builder type, with the default value read from the environment variable LOOM_STACK_SIZE, or 4096 if it is not set.

Fixes #309