### PR TITLE
Support setting model thread stack size

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -64,7 +64,7 @@ pub const MAX_THREADS: usize = 4;
 /// Maximum number of atomic store history to track per-cell.
 pub(crate) const MAX_ATOMIC_HISTORY: usize = 7;
 
-pub(crate) fn spawn<F>(f: F) -> crate::rt::thread::Id
+pub(crate) fn spawn<F>(stack_size: Option<usize>, f: F) -> crate::rt::thread::Id
 where
     F: FnOnce() + 'static,
 {
@@ -72,10 +72,13 @@ where
 
     trace!(thread = ?id, "spawn");
 
-    Scheduler::spawn(Box::new(move || {
-        f();
-        thread_done();
-    }));
+    Scheduler::spawn(
+        stack_size,
+        Box::new(move || {
+            f();
+            thread_done();
+        }),
+    );
 
     id
 }

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -171,7 +171,7 @@ impl RwLock {
 
     fn post_acquire_read_lock(&self) -> bool {
         super::execution(|execution| {
-            let mut state = self.state.get_mut(&mut execution.objects);
+            let state = self.state.get_mut(&mut execution.objects);
             let thread_id = execution.threads.active_id();
 
             // Set the lock to the current thread

--- a/src/rt/scheduler.rs
+++ b/src/rt/scheduler.rs
@@ -1,20 +1,14 @@
 #![allow(deprecated)]
 
-use crate::rt::{thread, Execution};
+use crate::rt::Execution;
 
 use generator::{self, Generator, Gn};
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::fmt;
 
 pub(crate) struct Scheduler {
-    /// Threads
-    threads: Vec<Thread>,
-
-    next_thread: usize,
-
-    queued_spawn: VecDeque<Box<dyn FnOnce()>>,
+    max_threads: usize,
 }
 
 type Thread = Generator<'static, Option<Box<dyn FnOnce()>>, ()>;
@@ -31,12 +25,8 @@ struct State<'a> {
 impl Scheduler {
     /// Create an execution
     pub(crate) fn new(capacity: usize) -> Scheduler {
-        let threads = spawn_threads(capacity);
-
         Scheduler {
-            threads,
-            next_thread: 0,
-            queued_spawn: VecDeque::new(),
+            max_threads: capacity,
         }
     }
 
@@ -83,9 +73,10 @@ impl Scheduler {
     where
         F: FnOnce() + Send + 'static,
     {
-        self.next_thread = 1;
-        self.threads[0].set_para(Some(Box::new(f)));
-        self.threads[0].resume();
+        let mut next_thread = 1;
+        let mut threads = spawn_threads(self.max_threads);
+        threads[0].set_para(Some(Box::new(f)));
+        threads[0].resume();
 
         loop {
             if !execution.threads.is_active() {
@@ -94,29 +85,29 @@ impl Scheduler {
 
             let active = execution.threads.active_id();
 
-            self.tick(active, execution);
+            let mut queued_spawn = Self::tick(&mut threads[active.as_usize()], execution);
 
-            while let Some(th) = self.queued_spawn.pop_front() {
-                let thread_id = self.next_thread;
-                self.next_thread += 1;
+            while let Some(th) = queued_spawn.pop_front() {
+                let thread_id = next_thread;
+                next_thread += 1;
 
-                self.threads[thread_id].set_para(Some(th));
-                self.threads[thread_id].resume();
+                threads[thread_id].set_para(Some(th));
+                threads[thread_id].resume();
             }
         }
     }
 
-    fn tick(&mut self, thread: thread::Id, execution: &mut Execution) {
+    fn tick(thread: &mut Thread, execution: &mut Execution) -> VecDeque<Box<dyn FnOnce()>> {
+        let mut queued_spawn = VecDeque::new();
         let state = RefCell::new(State {
             execution,
-            queued_spawn: &mut self.queued_spawn,
+            queued_spawn: &mut queued_spawn,
         });
-
-        let threads = &mut self.threads;
 
         STATE.set(unsafe { transmute_lt(&state) }, || {
-            threads[thread.as_usize()].resume();
+            thread.resume();
         });
+        queued_spawn
     }
 
     fn with_state<F, R>(f: F) -> R
@@ -128,14 +119,6 @@ impl Scheduler {
             are you accessing a Loom synchronization primitive from outside a Loom test (a call to `model` or `check`)?")
         }
         STATE.with(|state| f(&mut state.borrow_mut()))
-    }
-}
-
-impl fmt::Debug for Scheduler {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Schedule")
-            .field("threads", &self.threads)
-            .finish()
     }
 }
 

--- a/tests/thread_api.rs
+++ b/tests/thread_api.rs
@@ -105,6 +105,26 @@ fn thread_names() {
 }
 
 #[test]
+fn thread_stack_size() {
+    const STACK_SIZE: usize = 1 << 16;
+    loom::model(|| {
+        let body = || {
+            // Allocate a large array on the stack.
+            std::hint::black_box(&mut [0usize; STACK_SIZE]);
+        };
+        thread::Builder::new()
+            .stack_size(
+                // Include space for function calls in addition to the array.
+                2 * STACK_SIZE,
+            )
+            .spawn(body)
+            .unwrap()
+            .join()
+            .unwrap()
+    })
+}
+
+#[test]
 fn park_unpark_loom() {
     loom::model(|| {
         println!("unpark");


### PR DESCRIPTION
Make `loom::thread::Builder::stack_size` not a no-op. This is done by spawning scheduler threads later such that the requested stack size can be applied then.

Fixes #309 