### PR TITLE
Bump MSRV to 1.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.59.0 && rustup default 1.59.0
+        run: rustup update 1.60.0 && rustup default 1.60.0
       - name: Check
         run: cargo check --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"
 keywords = ["atomic", "lock-free"]
 categories = ["concurrency", "data-structures"]
+rust-version = "1.60.0"
 
 [features]
 default = []


### PR DESCRIPTION
We depend indirectly on `regex-syntax v0.7.1`, which has MSRV 1.60.0.