### PR TITLE
Increase max threads to 5

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use tracing::{info, subscriber};
 use tracing_subscriber::{fmt, EnvFilter};
 
-const DEFAULT_MAX_THREADS: usize = 4;
+const DEFAULT_MAX_THREADS: usize = 5;
 const DEFAULT_MAX_BRANCHES: usize = 1_000;
 
 /// Configure a model

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -59,7 +59,7 @@ pub(crate) use self::vv::VersionVec;
 use tracing::trace;
 
 /// Maximum number of threads that can be included in a model.
-pub const MAX_THREADS: usize = 4;
+pub const MAX_THREADS: usize = 5;
 
 /// Maximum number of atomic store history to track per-cell.
 pub(crate) const MAX_ATOMIC_HISTORY: usize = 7;


### PR DESCRIPTION
Tokio needs 5 threads to run loom tests now.

Five threads ought to be enough for anybody.