### PR TITLE
Add get_mut() to Mutex and RwLock

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -58,6 +58,11 @@ impl<T> Mutex<T> {
         }
     }
 
+    /// Returns a mutable reference to the underlying data.
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.data.get_mut()
+    }
+
     /// Consumes this mutex, returning the underlying data.
     pub fn into_inner(self) -> LockResult<T> {
         Ok(self.data.into_inner().unwrap())

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -60,7 +60,7 @@ impl<T> Mutex<T> {
 
     /// Returns a mutable reference to the underlying data.
     pub fn get_mut(&mut self) -> LockResult<&mut T> {
-        self.data.get_mut()
+        Ok(self.data.get_mut().unwrap())
     }
 
     /// Consumes this mutex, returning the underlying data.

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -108,7 +108,7 @@ impl<T> RwLock<T> {
 
     /// Returns a mutable reference to the underlying data.
     pub fn get_mut(&mut self) -> LockResult<&mut T> {
-        self.data.get_mut()
+        Ok(self.data.get_mut().expect("loom::RwLock state corrupt"))
     }
 
     /// Consumes this `RwLock`, returning the underlying data.

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -106,6 +106,11 @@ impl<T> RwLock<T> {
         }
     }
 
+    /// Returns a mutable reference to the underlying data.
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.data.get_mut()
+    }
+
     /// Consumes this `RwLock`, returning the underlying data.
     pub fn into_inner(self) -> LockResult<T> {
         Ok(self.data.into_inner().expect("loom::RwLock state corrupt"))


### PR DESCRIPTION
Add the standard library get_mut() method to Mutex and RwLock. This provides mutable access without locking for callers who already hold a &mut Mutex or &mut RwLock.