### PR TITLE
Enable user pruning of exploration branches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ macro_rules! dbg {
 #[macro_use]
 mod rt;
 
-pub use rt::explore_state;
+pub use rt::{explore, skip_branch, stop_exploring};
 // Expose for documentation purposes.
 pub use rt::MAX_THREADS;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,7 @@ macro_rules! dbg {
 #[macro_use]
 mod rt;
 
+pub use rt::explore_state;
 // Expose for documentation purposes.
 pub use rt::MAX_THREADS;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -52,6 +52,10 @@ pub struct Builder {
     /// Defaults to `LOOM_CHECKPOINT_INTERVAL` environment variable.
     pub checkpoint_interval: usize,
 
+    /// When `true` loom won't start state exploration until `explore_state` is
+    /// called.
+    pub expect_explicit_explore: bool,
+
     /// When `true`, locations are captured on each loom operation.
     ///
     /// Note that is is **very** expensive. It is recommended to first isolate a
@@ -117,6 +121,7 @@ impl Builder {
             preemption_bound,
             checkpoint_file,
             checkpoint_interval,
+            expect_explicit_explore: false,
             location,
             log,
         }
@@ -136,8 +141,12 @@ impl Builder {
         let mut i = 1;
         let mut _span = tracing::info_span!("iter", message = i).entered();
 
-        let mut execution =
-            Execution::new(self.max_threads, self.max_branches, self.preemption_bound);
+        let mut execution = Execution::new(
+            self.max_threads,
+            self.max_branches,
+            self.preemption_bound,
+            !self.expect_explicit_explore,
+        );
         let mut scheduler = Scheduler::new(self.max_threads);
 
         if let Some(ref path) = self.checkpoint_file {

--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -50,6 +50,7 @@ impl Execution {
         max_threads: usize,
         max_branches: usize,
         preemption_bound: Option<usize>,
+        exploring: bool,
     ) -> Execution {
         let id = Id::new();
         let threads = thread::Set::new(id, max_threads);
@@ -59,7 +60,7 @@ impl Execution {
 
         Execution {
             id,
-            path: Path::new(max_branches, preemption_bound),
+            path: Path::new(max_branches, preemption_bound, exploring),
             threads,
             lazy_statics: lazy_static::Set::new(),
             objects: object::Store::with_capacity(max_branches),

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -195,3 +195,10 @@ pub fn thread_done() {
         trace!(?thread, ?switch, "thread_done: terminate");
     });
 }
+
+/// TODO: docs
+pub fn explore_state() {
+    execution(|execution| {
+        execution.path.explore_state();
+    })
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -196,9 +196,27 @@ pub fn thread_done() {
     });
 }
 
-/// TODO: docs
-pub fn explore_state() {
+/// Tells loom to explore possible concurrent executions starting at this point.
+pub fn explore() {
     execution(|execution| {
         execution.path.explore_state();
     })
+}
+
+/// Tells loom to stop exploring possible concurrent executions starting at this
+/// point.
+///
+/// Exploration can be enabled again with `explore`.
+pub fn stop_exploring() {
+    execution(|execution| {
+        execution.path.critical();
+    })
+}
+
+/// Tells loom to stop exploring possible concurrent execution starting at this
+/// point.
+///
+/// Unlike `stop_exploring`, exploration cannot be restarted by `explore`.
+pub fn skip_branch() {
+    execution(|execution| execution.path.skip_branch())
 }


### PR DESCRIPTION
This will help setup complex tests that aim to cover specific cases without doing an exhaustive search.