### PR TITLE
Implement AsRef and Borrow for Arc

### DIFF
--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -1,5 +1,6 @@
 use crate::rt;
 
+use std::borrow::Borrow;
 use std::pin::Pin;
 use std::{mem, ops, ptr};
 
@@ -265,5 +266,19 @@ impl<T> From<T> for Arc<T> {
     #[track_caller]
     fn from(t: T) -> Self {
         Arc::new(t)
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for Arc<T> {
+    #[track_caller]
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for Arc<T> {
+    #[track_caller]
+    fn borrow(&self) -> &T {
+        self
     }
 }

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -270,14 +270,12 @@ impl<T> From<T> for Arc<T> {
 }
 
 impl<T: ?Sized> AsRef<T> for Arc<T> {
-    #[track_caller]
     fn as_ref(&self) -> &T {
         self
     }
 }
 
 impl<T: ?Sized> Borrow<T> for Arc<T> {
-    #[track_caller]
     fn borrow(&self) -> &T {
         self
     }


### PR DESCRIPTION
These traits are necessary to use the Arc in places that expect AsRef and Borrow.