### PR TITLE
Use core instead of std in lazy_static! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ macro_rules! __lazy_static_internal {
                     static LAZY: $crate::lazy_static::Lazy<$T> =
                         $crate::lazy_static::Lazy {
                             init: __static_ref_initialize,
-                            _p: std::marker::PhantomData,
+                            _p: core::marker::PhantomData,
                         };
                     LAZY.get()
                 }


### PR DESCRIPTION
In order to let the `loom::lazy_static` macro work in contexts that are `#[no_std]`, use `marker::PhantomData` from `core` instead of `std`.