### PR TITLE
feat: add loom::cell::Cell::into_inner

### DIFF
--- a/src/cell/cell.rs
+++ b/src/cell/cell.rs
@@ -67,6 +67,12 @@ impl<T> Cell<T> {
     {
         self.replace(T::default())
     }
+
+    /// Unwraps the value, consuming the cell.
+    #[track_caller]
+    pub fn into_inner(self) -> T {
+        self.cell.into_inner()
+    }
 }
 
 impl<T: Default> Default for Cell<T> {


### PR DESCRIPTION
Thanks for loom! I don't have sufficient context to know if there is a reason for this absence, but I ran into this difference between std::cell::Cell and loom::cell::Cell and it seemed easy enough to fix