### PR TITLE
Fix dead code warning

### DIFF
--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -76,7 +76,7 @@ impl Id {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum State {
     Runnable { unparked: bool },
-    Blocked(Location),
+    Blocked(#[allow(dead_code)] Location),
     Yield,
     Terminated,
 }


### PR DESCRIPTION
This fixes a compile failure due to the latest 1.77 changes.