### PR TITLE
feat: implement into_inner for loom Arc

### DIFF
--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -54,6 +54,27 @@ impl<T> Arc<T> {
             Err(_) => unreachable!(),
         }
     }
+
+    /// Returns the inner value, if the `Arc` has exactly one strong reference.
+    #[track_caller]
+    pub fn into_inner(this: Arc<T>) -> Option<T> {
+        // work around our inability to destruct the object normally,
+        // because of the `Drop` presense.
+        this.obj.ref_dec(location!());
+        this.unregister();
+
+        let (obj, value) = unsafe {
+            let obj = ptr::read(&this.obj);
+            let value = ptr::read(&this.value);
+
+            mem::forget(this);
+
+            (obj, value)
+        };
+
+        let _ = std::sync::Arc::into_inner(obj);
+        std::sync::Arc::into_inner(value)
+    }
 }
 
 impl<T: ?Sized> Arc<T> {

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -69,9 +69,7 @@ impl<T> Arc<T> {
             (obj, value)
         };
 
-        obj.ref_dec(location!());
-
-        if std::sync::Arc::into_inner(obj).is_some() {
+        if obj.ref_dec(location!()) {
             // unregister
             rt::execution(|e| {
                 e.arc_objs


### PR DESCRIPTION
As titled.

Implement a mocked [Arc::into_inner](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.into_inner)