### PR TITLE
Implement `wait_while` for condvar

### DIFF
--- a/src/sync/condvar.rs
+++ b/src/sync/condvar.rs
@@ -39,6 +39,23 @@ impl Condvar {
         Ok(guard)
     }
 
+    /// Blocks the current thread until this condition variable receives a notification and the
+    /// provided condition is false.
+    pub fn wait_while<'a, T, F>(
+        &self,
+        mut guard: MutexGuard<'a, T>,
+        mut condition: F,
+    ) -> LockResult<MutexGuard<'a, T>>
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        while condition(&mut *guard) {
+            guard = self.wait(guard)?;
+        }
+
+        Ok(guard)
+    }
+
     /// Waits on this condition variable for a notification, timing out after a
     /// specified duration.
     pub fn wait_timeout<'a, T>(


### PR DESCRIPTION

**Problem**
I am using loom for concurrent tests, and `wait_while` was a feature I needed for the crate to be compatible with the project.

**Changes**
I implemented the `wait_while` function and added a test for it.