### PR TITLE
Fix doc link typo in hint.rs

### DIFF
--- a/src/hint.rs
+++ b/src/hint.rs
@@ -20,7 +20,7 @@ pub fn spin_loop() {
 /// simulated version of [`std::hint::unreachable_unchecked`], which is unsafe.
 ///
 /// See [the documentation for
-/// `std::hint::unreachable_unchecked`](`std::hint::unreachable_unchecked#Safety)
+/// `std::hint::unreachable_unchecked`](std::hint::unreachable_unchecked#Safety)
 /// for safety details.
 #[track_caller]
 pub unsafe fn unreachable_unchecked() -> ! {


### PR DESCRIPTION
There’s a minor typo in a doc link in hint.rs.