### PR TITLE
Bump MSRV to 1.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"
 keywords = ["atomic", "lock-free"]
 categories = ["concurrency", "data-structures"]
-rust-version = "1.77"
+rust-version = "1.73"
 
 [features]
 default = []
@@ -46,3 +46,6 @@ futures-util = "0.3.0"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+generator = { git = "https://github.com/taiki-e/generator-rs.git", branch = "msrv" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,3 @@ futures-util = "0.3.0"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-[patch.crates-io]
-generator = { git = "https://github.com/taiki-e/generator-rs.git", branch = "msrv" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/tokio-rs/loom"
 readme = "README.md"
 keywords = ["atomic", "lock-free"]
 categories = ["concurrency", "data-structures"]
-rust-version = "1.65"
+rust-version = "1.77"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ scoped-tls = "1.0.0"
 generator = "0.8.1"
 
 # Requires for "checkpoint" feature
-serde = { version = "1.0.92", features = ["derive"], optional = true }
+serde = { version = "1.0.113", features = ["derive"], optional = true }
 serde_json = { version = "1.0.33", optional = true }
 
 # Requires for "futures" feature

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -199,7 +199,7 @@ impl<T> Store<T> {
             })
     }
 
-    pub(super) fn iter_mut<'a, O>(&'a mut self) -> impl DoubleEndedIterator<Item = &mut O>
+    pub(super) fn iter_mut<'a, O>(&'a mut self) -> impl DoubleEndedIterator<Item = &'a mut O>
     where
         O: Object<Entry = T> + 'a,
     {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -280,7 +280,7 @@ impl<T: 'static> LocalKey<T> {
         Ok(f(value))
     }
 
-    unsafe fn get(&'static self) -> Option<Result<&T, AccessError>> {
+    unsafe fn get(&'static self) -> Option<Result<&'static T, AccessError>> {
         unsafe fn transmute_lt<'a, 'b, T>(t: &'a T) -> &'b T {
             std::mem::transmute::<&'a T, &'b T>(t)
         }


### PR DESCRIPTION
```
  error: package `generator v0.8.3` cannot be built because it requires rustc 1.77 or newer, while the currently active rustc version is 1.65.0
```
https://github.com/tokio-rs/loom/actions/runs/10867411903/job/30156136540#step:4:60


Depend on https://github.com/Xudong-Huang/generator-rs/pull/68