### PR TITLE
Use std::pin::pin! macro instead of pin-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.73"
 [features]
 default = []
 checkpoint = ["serde", "serde_json"]
-futures = ["pin-utils"]
+futures = []
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -33,9 +33,6 @@ generator = "0.8.1"
 # Requires for "checkpoint" feature
 serde = { version = "1.0.113", features = ["derive"], optional = true }
 serde_json = { version = "1.0.33", optional = true }
-
-# Requires for "futures" feature
-pin-utils = { version = "0.1.0", optional = true }
 
 tracing = { version = "0.1.27", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.8", features = ["env-filter"] }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -7,9 +7,9 @@ pub use self::atomic_waker::AtomicWaker;
 use crate::rt;
 use crate::sync::Arc;
 
-use pin_utils::pin_mut;
 use std::future::Future;
 use std::mem;
+use std::pin::pin;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 /// Block the current thread, driving `f` to completion.
@@ -18,7 +18,7 @@ pub fn block_on<F>(f: F) -> F::Output
 where
     F: Future,
 {
-    pin_mut!(f);
+    let mut f = pin!(f);
 
     let notify = Arc::new(rt::Notify::new(false, true));
 


### PR DESCRIPTION
Depend on #364.

`std::pin::pin!` macro has been stabilized in Rust 1.68.