### PR TITLE
Fix build error on not 64 bit arch

### DIFF
--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -190,8 +190,8 @@ atomic_int!(AtomicI16, i16);
 atomic_int!(AtomicI32, i32);
 atomic_int!(AtomicIsize, isize);
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_has_atomic = "64")]
 atomic_int!(AtomicU64, u64);
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_has_atomic = "64")]
 atomic_int!(AtomicI64, i64);

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -11,7 +11,7 @@ mod int;
 pub use self::int::{AtomicI16, AtomicI32, AtomicI8, AtomicIsize};
 pub use self::int::{AtomicU16, AtomicU32, AtomicU8, AtomicUsize};
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_has_atomic = "64")]
 pub use self::int::{AtomicI64, AtomicU64};
 
 mod ptr;

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -8,8 +8,11 @@ mod bool;
 pub use self::bool::AtomicBool;
 
 mod int;
-pub use self::int::{AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize};
-pub use self::int::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize};
+pub use self::int::{AtomicI16, AtomicI32, AtomicI8, AtomicIsize};
+pub use self::int::{AtomicU16, AtomicU32, AtomicU8, AtomicUsize};
+
+#[cfg(target_pointer_width = "64")]
+pub use self::int::{AtomicI64, AtomicU64};
 
 mod ptr;
 pub use self::ptr::AtomicPtr;


### PR DESCRIPTION
`AtomicU64` and `AtomicI64` are defined only if `target_pointer_width = 64`

https://github.com/tokio-rs/loom/blob/3ef62e2011cb3b3baf76251f42b8c6c1a12d555d/src/sync/atomic/int.rs#L193-L197

But they are exported for all targets

https://github.com/tokio-rs/loom/blob/3ef62e2011cb3b3baf76251f42b8c6c1a12d555d/src/sync/atomic/mod.rs#L10-L12