### PR TITLE
internal: support const on `UnsafeCell`

### DIFF
--- a/src/cell/unsafe_cell.rs
+++ b/src/cell/unsafe_cell.rs
@@ -104,7 +104,7 @@ pub struct MutPtr<T: ?Sized> {
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified value.
     #[track_caller]
-    pub fn new(data: T) -> UnsafeCell<T> {
+    pub const fn new(data: T) -> UnsafeCell<T> {
         let state = rt::Cell::new(location!());
 
         UnsafeCell {


### PR DESCRIPTION
This method was `const` since 1.32 (https://doc.rust-lang.org/stable/std/cell/struct.UnsafeCell.html#method.new) and some code in [Salsa](https://github.com/salsa-rs/salsa/) makes use of creating `UnsafeCell`s in const contexts.

(Salsa is heavily used used by rust-analyzer and I'm spending a bit of time to make sure rust-analyzer's dependencies are reliable.)