### PR TITLE
add `as_mut` to mutably access owned or mutably borrowed `UnsafeCell` safely

### DIFF
--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -5,4 +5,4 @@ mod cell;
 mod unsafe_cell;
 
 pub use self::cell::Cell;
-pub use self::unsafe_cell::{ConstPtr, MutPtr, UnsafeCell};
+pub use self::unsafe_cell::{ConstPtr, MutPtr, MutRef, UnsafeCell};

--- a/tests/unsafe_cell.rs
+++ b/tests/unsafe_cell.rs
@@ -333,3 +333,12 @@ fn unsafe_cell_access_after_sync() {
         }
     });
 }
+
+#[test]
+fn as_mut_is_ergonomical_and_safe() {
+    loom::model(|| {
+        let mut value = UnsafeCell::new(-3i32);
+        let mut mut_ref = value.as_mut();
+        *mut_ref = mut_ref.abs();
+    });
+}


### PR DESCRIPTION
See title.

This is the equivalent to [`core::cell::UnsafeCell::get_mut`][0], but with tracking. Instead of forcing unnecessary `unsafe` on users, we can simply give them mutable access to an owned value.

An example of where this causes unnecessary unsafe to be used can be found [here][1].

[0]: https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html#method.get_mut
[1]: https://github.com/rtic-rs/rtic/pull/1038/files#r2009037113