### PR TITLE
fix: Prevent false-positive deadlocks on try_lock

### DIFF
--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -47,6 +47,9 @@ impl Mutex {
     }
 
     pub(crate) fn try_acquire_lock(&self, location: Location) -> bool {
+        if self.is_locked() {
+            return false;
+        }
         self.state.branch_opaque(location);
         self.post_acquire()
     }

--- a/src/rt/rwlock.rs
+++ b/src/rt/rwlock.rs
@@ -79,11 +79,17 @@ impl RwLock {
     }
 
     pub(crate) fn try_acquire_read_lock(&self, location: Location) -> bool {
+        if self.is_write_locked() {
+            return false;
+        }
         self.state.branch_action(Action::Read, location);
         self.post_acquire_read_lock()
     }
 
     pub(crate) fn try_acquire_write_lock(&self, location: Location) -> bool {
+        if self.is_write_locked() || self.is_read_locked() {
+            return false;
+        }
         self.state.branch_action(Action::Write, location);
         self.post_acquire_write_lock()
     }

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -91,3 +91,21 @@ fn mutex_into_inner() {
         assert_eq!(lock, 2);
     })
 }
+
+#[test]
+fn try_lock_no_block() {
+    loom::model(|| {
+        let lock = Rc::new(Mutex::new(0));
+        let lock2 = lock.clone();
+
+        let th = thread::spawn(move || {
+            let _ = lock.try_lock();
+        });
+
+        let guard = lock2.try_lock();
+
+        th.join().unwrap();
+
+        drop(guard)
+    })
+}

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -162,3 +162,21 @@ fn rwlock_into_inner() {
         assert_eq!(lock, 2);
     })
 }
+
+#[test]
+fn rwlock_try_write_no_block() {
+    loom::model(|| {
+        let lock = Rc::new(RwLock::new(0));
+        let lock2 = lock.clone();
+
+        let th = thread::spawn(move || {
+            let _ = lock.try_read();
+        });
+
+        let guard = lock2.try_write();
+
+        th.join().unwrap();
+
+        drop(guard)
+    })
+}


### PR DESCRIPTION
Fixes #376 

```rust
#[test]
fn try_lock_no_block() {
    loom::model(|| {
        let lock = Rc::new(Mutex::new(0));
        let lock2 = lock.clone();

        let th = thread::spawn(move || {
            let _ = lock.try_lock(); // A
        });

        let guard = lock2.try_lock(); // B

        th.join().unwrap();

        drop(guard)
    })
}
```

With the above code, in some execution paths, the following happens:

1. Thread 0 tries to acquire B then switched into thread 1 before finishing it
2. Thread 1 tries to acquire A and blocks thread 0 in the following lines
https://github.com/tokio-rs/loom/blob/dbf32b04bae821c64be44405a0bb72ca08741558/src/rt/mutex.rs#L115-L129
3. Thread 0 is blocked, so it cannot join the thread handle

Similar thing happens with `RwLock` and the simple short circuit code I added prevents such paths
