### PR TITLE
Update dependency `tracing-subscriber` to 0.3.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.113", features = ["derive"], optional = true }
 serde_json = { version = "1.0.33", optional = true }
 
 tracing = { version = "0.1.27", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.8", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [dev-dependencies]
 futures-util = "0.3.0"


### PR DESCRIPTION
This brings `loom` in line with the fix for [RUSTSEC-2025-0055](https://rustsec.org/advisories/RUSTSEC-2025-0055.html).