### PR TITLE
Fix #406

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -26,6 +26,13 @@ pub struct Lazy<T> {
 
 impl<T: 'static> Lazy<T> {
     /// Mock implementation of `lazy_static::Lazy::get`.
+    ///
+    /// # Safety
+    /// The returned reference is typed as `&'static T`, but the underlying value
+    /// only lives for the duration of the current loom execution. Callers must
+    /// ensure that the reference does not escape the current execution, such as
+    /// by storing it in state that is later accessed after [`crate::model()`]
+    /// returns.
     pub fn get(&'static self) -> &'static T {
         // This is not great. Specifically, we're returning a 'static reference to a value that
         // only lives for the duration of the execution. Unfortunately, the semantics of lazy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@
 //! tests, the `std` should be used, since the loom runtime won't be active. This means that
 //! library code will need to use conditional compilation to decide which types to use.
 //!
+//! Loom's mock `lazy_static` support is only valid while a modeled execution is
+//! active. References obtained from it must not escape the current
+//! [`model`](mod@model) execution.
+//!
 //! It is recommended to use a `loom` cfg flag to signal using the loom types. You can do this by
 //! passing `RUSTFLAGS="--cfg loom"` as part of the command when you want to run the loom tests.
 //! Then modify your `Cargo.toml` to include loom like this:


### PR DESCRIPTION
This pull request adds safety documentation to the mock `lazy_static` implementation, clarifying the lifetime and usage constraints of references returned during loom model execution. This PR aims to solve the #406 by adding "#safety" section to remind users the caveat.

Documentation improvements:

* Added a detailed safety section to the `Lazy::get` method, explaining that the returned `&'static T` reference is only valid for the duration of the current loom execution and must not escape it.
* Updated the crate-level documentation in `src/lib.rs` to warn users that references from loom's mock `lazy_static` are only valid during a modeled execution.