### PR TITLE
Rename `fetch_update` to `try_update`

### DIFF
--- a/src/sync/atomic/atomic.rs
+++ b/src/sync/atomic/atomic.rs
@@ -96,7 +96,7 @@ where
     }
 
     #[track_caller]
-    pub(crate) fn fetch_update<F>(
+    pub(crate) fn try_update<F>(
         &self,
         set_order: Ordering,
         fetch_order: Ordering,

--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -126,7 +126,7 @@ impl AtomicBool {
     }
 
     /// An alias for [`Self::try_update`].
-    #[deprecated = "renamed to try_update for consistency"]
+    #[deprecated = "renamed to `try_update` for consistency"]
     #[track_caller]
     pub fn fetch_update<F>(
         &self,

--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -113,6 +113,21 @@ impl AtomicBool {
     /// a [`Result`] of [`Ok`]`(previous_value)` if the function returned [`Some`]`(_)`, else
     /// [`Err`]`(previous_value)`.
     #[track_caller]
+    pub fn try_update<F>(
+        &self,
+        set_order: Ordering,
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<bool, bool>
+    where
+        F: FnMut(bool) -> Option<bool>,
+    {
+        self.0.try_update(set_order, fetch_order, f)
+    }
+
+    /// An alias for [`Self::try_update`].
+    #[deprecated = "renamed to try_update for consistency"]
+    #[track_caller]
     pub fn fetch_update<F>(
         &self,
         set_order: Ordering,
@@ -122,7 +137,7 @@ impl AtomicBool {
     where
         F: FnMut(bool) -> Option<bool>,
     {
-        self.0.fetch_update(set_order, fetch_order, f)
+        self.try_update(set_order, fetch_order, f)
     }
 }
 

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -166,7 +166,7 @@ macro_rules! atomic_int {
             }
 
             /// An alias for [`Self::try_update`].
-            #[deprecated = "renamed to try_update for consistency"]
+            #[deprecated = "renamed to `try_update` for consistency"]
             #[track_caller]
             pub fn fetch_update<F>(
                 &self,

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -153,6 +153,21 @@ macro_rules! atomic_int {
             /// Returns a [`Result`] of [`Ok`]`(previous_value)` if the function returned
             /// [`Some`]`(_)`, else [`Err`]`(previous_value)`.
             #[track_caller]
+            pub fn try_update<F>(
+                &self,
+                set_order: Ordering,
+                fetch_order: Ordering,
+                f: F,
+            ) -> Result<$int_type, $int_type>
+            where
+                F: FnMut($int_type) -> Option<$int_type>,
+            {
+                self.0.try_update(set_order, fetch_order, f)
+            }
+
+            /// An alias for [`Self::try_update`].
+            #[deprecated = "renamed to try_update for consistency"]
+            #[track_caller]
             pub fn fetch_update<F>(
                 &self,
                 set_order: Ordering,
@@ -162,7 +177,7 @@ macro_rules! atomic_int {
             where
                 F: FnMut($int_type) -> Option<$int_type>,
             {
-                self.0.fetch_update(set_order, fetch_order, f)
+                self.try_update(set_order, fetch_order, f)
             }
         }
 

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -99,6 +99,21 @@ impl<T> AtomicPtr<T> {
     /// a [`Result`] of [`Ok`]`(previous_value)` if the function returned [`Some`]`(_)`, else
     /// [`Err`]`(previous_value)`.
     #[track_caller]
+    pub fn try_update<F>(
+        &self,
+        set_order: Ordering,
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<*mut T, *mut T>
+    where
+        F: FnMut(*mut T) -> Option<*mut T>,
+    {
+        self.0.try_update(set_order, fetch_order, f)
+    }
+
+    /// An alias for [`Self::try_update`].
+    #[deprecated = "renamed to try_update for consistency"]
+    #[track_caller]
     pub fn fetch_update<F>(
         &self,
         set_order: Ordering,
@@ -108,7 +123,7 @@ impl<T> AtomicPtr<T> {
     where
         F: FnMut(*mut T) -> Option<*mut T>,
     {
-        self.0.fetch_update(set_order, fetch_order, f)
+        self.try_update(set_order, fetch_order, f)
     }
 }
 

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -112,7 +112,7 @@ impl<T> AtomicPtr<T> {
     }
 
     /// An alias for [`Self::try_update`].
-    #[deprecated = "renamed to try_update for consistency"]
+    #[deprecated = "renamed to `try_update` for consistency"]
     #[track_caller]
     pub fn fetch_update<F>(
         &self,

--- a/tests/atomic_int.rs
+++ b/tests/atomic_int.rs
@@ -81,14 +81,14 @@ macro_rules! test_int {
             }
 
             #[test]
-            fn fetch_update() {
+            fn try_update() {
                 loom::model(|| {
                     let a: $int = NUM_A as $int;
                     let b: $int = NUM_B as $int;
 
                     let atomic = <$atomic>::new(a);
-                    assert_eq!(Ok(a), atomic.fetch_update(SeqCst, SeqCst, |_| Some(b)));
-                    assert_eq!(Err(b), atomic.fetch_update(SeqCst, SeqCst, |_| None));
+                    assert_eq!(Ok(a), atomic.try_update(SeqCst, SeqCst, |_| Some(b)));
+                    assert_eq!(Err(b), atomic.try_update(SeqCst, SeqCst, |_| None));
                     assert_eq!(b, atomic.load(SeqCst));
                 });
             }


### PR DESCRIPTION
This is in line with `std` renaming the functions and deprecating the old `fetch_update` API (which will reach stable with Rust 1.99).